### PR TITLE
refactor(rezervo-type): remove unused userPosition

### DIFF
--- a/src/lib/integration/adapters.ts
+++ b/src/lib/integration/adapters.ts
@@ -20,10 +20,7 @@ function sitToRezervoClass(sitClass: SitClass): RezervoClass {
         isBookable: sitClass.bookable,
         totalSlots: sitClass.capacity,
         availableSlots: sitClass.available,
-        waitingList: {
-            count: sitClass.waitlist.count,
-            userPosition: sitClass.waitlist.userPosition,
-        },
+        waitingListCount: sitClass.waitlist.count,
         activity: {
             id: sitClass.activityId,
             name: sitClass.name,
@@ -61,10 +58,7 @@ function fscToRezervoClass(fscClass: FscClass): RezervoClass {
             DateTime.fromISO(fscClass.bookableLatest) > DateTime.now(),
         totalSlots: fscClass.slots.total,
         availableSlots: fscClass.slots.leftToBook,
-        waitingList: {
-            count: fscClass.slots.inWaitingList,
-            userPosition: null, // TODO: missing here
-        },
+        waitingListCount: fscClass.slots.inWaitingList,
         activity: {
             id: fscClass.groupActivityProduct.id,
             name: fscClass.groupActivityProduct.name,

--- a/src/lib/popularity.ts
+++ b/src/lib/popularity.ts
@@ -33,8 +33,8 @@ export function stringifyClassPopularity(_class: RezervoClass, historicPopularit
         classPopularityInfo = historicPopularity;
     }
 
-    if (_class.waitingList.count > 0) {
-        classPopularityInfo += ` | ${_class.waitingList.count} ${isInThePast ? "fikk ikke plass" : "er på venteliste"}`;
+    if (_class.waitingListCount > 0) {
+        classPopularityInfo += ` | ${_class.waitingListCount} ${isInThePast ? "fikk ikke plass" : "er på venteliste"}`;
     }
     return classPopularityInfo;
 }

--- a/src/types/integration/sit.ts
+++ b/src/types/integration/sit.ts
@@ -27,7 +27,6 @@ export type SitClass = {
     waitlist: {
         active: boolean;
         count: number;
-        userPosition: number | null;
     };
 };
 

--- a/src/types/rezervo.ts
+++ b/src/types/rezervo.ts
@@ -115,10 +115,7 @@ interface RezervoClassBase {
     isBookable: boolean;
     totalSlots: number;
     availableSlots: number;
-    waitingList: {
-        count: number;
-        userPosition: number | null;
-    };
+    waitingListCount: number;
     activity: RezervoActivity;
     instructors: string[];
 }


### PR DESCRIPTION
This field is unused, and does not make sense, since we do not have any info about _a user_ when we fetch the rezervo schedule. Whether the user is in a waiting list and which position it has is done elsewhere, and thus it is redundant to have it here. 

I still think we should keep it in the Sit type however, even though it is not used. This is because the Sit API actually returns a userPosition: null, and I think the integration type should resemble the actual API responses as closely as possible. Open to remove it though, if you have a stance here.