### PR TITLE
fix(ClassInfo): image overflow after Next upgrade

### DIFF
--- a/components/modals/ClassInfo/ClassInfo.tsx
+++ b/components/modals/ClassInfo/ClassInfo.tsx
@@ -231,12 +231,11 @@ export default function ClassInfo({
                 </Box>
             )}
             {_class.activity.image && (
-                <Box pt={2}>
+                <Box pt={2} sx={{ position: "relative", height: 300 }}>
                     <Image
                         src={_class.activity.image}
                         alt={_class.activity.name}
-                        width={600}
-                        height={300}
+                        fill
                         style={{
                             objectFit: "cover",
                             borderRadius: "0.25em",


### PR DESCRIPTION
## Before
<img width="633" alt="Screenshot 2023-09-03 at 16 28 50" src="https://github.com/mathiazom/rezervo-web/assets/26925695/1b681af2-3f6b-4a6d-80c8-1279d40b1ae4">

## After
<img width="625" alt="Screenshot 2023-09-03 at 16 28 41" src="https://github.com/mathiazom/rezervo-web/assets/26925695/a2478f72-6839-40d5-b2f0-53026d10d3fa">
