### PR TITLE
fix(ClassInfo): hide slot preview if in the past

### DIFF
--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -174,7 +174,7 @@ export default function ClassInfo({
                     {_class.instructors.join(", ")}
                 </Typography>
             </Box>
-            {!_class.isBookable && (
+            {!_class.isBookable && !isClassInThePast(_class) && (
                 <Box
                     sx={{
                         display: "flex",


### PR DESCRIPTION
The classes in the past already have information about how many people attended as well as how many spots there were available.

## Before
<img width="624" alt="Screenshot 2023-09-12 at 17 40 54" src="https://github.com/mathiazom/rezervo-web/assets/26925695/f0f19a1b-9961-4fb8-8c26-6f9bd923e28a">

## After
<img width="624" alt="Screenshot 2023-09-12 at 17 40 45" src="https://github.com/mathiazom/rezervo-web/assets/26925695/7bf8cc6c-b5bd-46df-995a-da9e28dd2c35">
