### PR TITLE
feat(ClassInfoModal): display class weekday

### DIFF
--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -1,6 +1,7 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { Diversity3Rounded } from "@mui/icons-material";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import LocationOnRoundedIcon from "@mui/icons-material/LocationOnRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
@@ -142,9 +143,22 @@ export default function ClassInfo({
                     alignItems: "center",
                 }}
             >
+                <CalendarMonthIcon />
+                <Typography variant="body2" color="text.secondary">
+                    {_class.startTime.toFormat("EEEE d. LLLL")}
+                </Typography>
+            </Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    paddingTop: 1,
+                    gap: 1,
+                    alignItems: "center",
+                }}
+            >
                 <AccessTimeRoundedIcon />
                 <Typography variant="body2" color="text.secondary">
-                    {_class.startTime.toFormat("HH:mm")} - {_class.endTime.toFormat("HH:mm")}
+                    {_class.startTime.toFormat("HH:mm")}–{_class.endTime.toFormat("HH:mm")}
                 </Typography>
             </Box>
             <Box


### PR DESCRIPTION
## Before
<img width="619" alt="Screenshot 2023-09-18 at 09 35 25" src="https://github.com/mathiazom/rezervo-web/assets/26925695/03d12af8-ace0-487d-bd0f-2babaf59d68e">

## After
<img width="619" alt="Screenshot 2023-09-18 at 10 49 07" src="https://github.com/mathiazom/rezervo-web/assets/26925695/ee2d1c64-85f0-4778-8e43-8ad9b75119f1">


Resolves https://github.com/mathiazom/rezervo/issues/20