### PR TITLE
feat(Settings): hide notification hours before if Slack is not configured for the user

### DIFF
--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -308,80 +308,91 @@ export default function Settings({
                     </FormGroup>
                     <PushNotifications />
                     <Divider orientation="horizontal" />
-                    <FormGroup>
-                        <FormLabel>
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
-                                <NotificationsActiveRoundedIcon />
-                                <Typography
-                                    sx={{
-                                        userSelect: "none",
-                                    }}
-                                >
-                                    Påminnelse om time
-                                </Typography>
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                        justifyContent: "right",
-                                        flexGrow: 1,
-                                    }}
-                                >
-                                    {notificationsConfigLoading && <CircularProgress size="1rem" />}
-                                    <Switch
-                                        checked={reminderActive}
-                                        onChange={(_, checked) => handleReminderActiveChanged(checked)}
-                                        inputProps={{
-                                            "aria-label": "påminnelse-aktiv",
-                                        }}
-                                    />
+                    {preferences?.notifications?.slack_notifications && (
+                        <>
+                            <FormGroup>
+                                <FormLabel>
+                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
+                                        <NotificationsActiveRoundedIcon />
+                                        <Typography
+                                            sx={{
+                                                userSelect: "none",
+                                            }}
+                                        >
+                                            Påminnelse om time
+                                        </Typography>
+                                        <Box
+                                            sx={{
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "right",
+                                                flexGrow: 1,
+                                            }}
+                                        >
+                                            {notificationsConfigLoading && <CircularProgress size="1rem" />}
+                                            <Switch
+                                                checked={reminderActive}
+                                                onChange={(_, checked) => handleReminderActiveChanged(checked)}
+                                                inputProps={{
+                                                    "aria-label": "påminnelse-aktiv",
+                                                }}
+                                            />
+                                        </Box>
+                                    </Box>
+                                </FormLabel>
+                                <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", ml: "33px", pb: 1 }}>
+                                    <FormControl>
+                                        <TextField
+                                            disabled={!reminderActive || reminderHoursBefore == null}
+                                            inputProps={{ inputMode: "numeric" }}
+                                            value={
+                                                reminderTimeBeforeInput ??
+                                                (reminderHoursBefore ?? DEFAULT_REMINDER_HOURS).toString()
+                                            }
+                                            onChange={({ target: { value } }) => setReminderTimeBeforeInput(value)}
+                                            onBlur={() =>
+                                                reminderTimeBeforeInput != null &&
+                                                reminderTimeBeforeInputUnit != null &&
+                                                handleReminderHoursChanged(
+                                                    reminderTimeBeforeInput,
+                                                    reminderTimeBeforeInputUnit,
+                                                )
+                                            }
+                                            sx={{ width: "4rem" }}
+                                            size={"small"}
+                                        />
+                                    </FormControl>
+                                    <FormLabel disabled={!reminderActive}>
+                                        <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                                            <Select
+                                                disabled={!reminderActive || reminderHoursBefore == null}
+                                                value={
+                                                    reminderTimeBeforeInputUnit ??
+                                                    reminderTimeBeforeInputUnitFromHours(
+                                                        reminderHoursBefore ?? DEFAULT_REMINDER_HOURS,
+                                                    )
+                                                }
+                                                onChange={({ target: { value } }) => {
+                                                    handleReminderHoursUnitChanged(
+                                                        value as ReminderTimeBeforeInputUnit,
+                                                    );
+                                                }}
+                                                inputProps={{ "aria-label": "Without label" }}
+                                                size={"small"}
+                                            >
+                                                <MenuItem value={ReminderTimeBeforeInputUnit.HOURS}>timer</MenuItem>
+                                                <MenuItem value={ReminderTimeBeforeInputUnit.MINUTES}>
+                                                    minutter
+                                                </MenuItem>
+                                            </Select>
+                                            <Typography>før start</Typography>
+                                        </Box>
+                                    </FormLabel>
                                 </Box>
-                            </Box>
-                        </FormLabel>
-                        <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", ml: "33px", pb: 1 }}>
-                            <FormControl>
-                                <TextField
-                                    disabled={!reminderActive || reminderHoursBefore == null}
-                                    inputProps={{ inputMode: "numeric" }}
-                                    value={
-                                        reminderTimeBeforeInput ??
-                                        (reminderHoursBefore ?? DEFAULT_REMINDER_HOURS).toString()
-                                    }
-                                    onChange={({ target: { value } }) => setReminderTimeBeforeInput(value)}
-                                    onBlur={() =>
-                                        reminderTimeBeforeInput != null &&
-                                        reminderTimeBeforeInputUnit != null &&
-                                        handleReminderHoursChanged(reminderTimeBeforeInput, reminderTimeBeforeInputUnit)
-                                    }
-                                    sx={{ width: "4rem" }}
-                                    size={"small"}
-                                />
-                            </FormControl>
-                            <FormLabel disabled={!reminderActive}>
-                                <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
-                                    <Select
-                                        disabled={!reminderActive || reminderHoursBefore == null}
-                                        value={
-                                            reminderTimeBeforeInputUnit ??
-                                            reminderTimeBeforeInputUnitFromHours(
-                                                reminderHoursBefore ?? DEFAULT_REMINDER_HOURS,
-                                            )
-                                        }
-                                        onChange={({ target: { value } }) => {
-                                            handleReminderHoursUnitChanged(value as ReminderTimeBeforeInputUnit);
-                                        }}
-                                        inputProps={{ "aria-label": "Without label" }}
-                                        size={"small"}
-                                    >
-                                        <MenuItem value={ReminderTimeBeforeInputUnit.HOURS}>timer</MenuItem>
-                                        <MenuItem value={ReminderTimeBeforeInputUnit.MINUTES}>minutter</MenuItem>
-                                    </Select>
-                                    <Typography>før start</Typography>
-                                </Box>
-                            </FormLabel>
-                        </Box>
-                    </FormGroup>
-                    <Divider />
+                            </FormGroup>
+                            <Divider />
+                        </>
+                    )}
                     <CalendarFeed />
                 </FormGroup>
             </Box>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -27,6 +27,7 @@ export type IntegrationUserPayload = IntegrationUser & {
 
 export type NotificationsConfig = {
     reminder_hours_before: number | null;
+    slack_notifications?: boolean;
 };
 
 export type Preferences = {


### PR DESCRIPTION
This PR hides the settings for configuring reminders about classes x hours before, if the user does not have a Slack config. This is necessary once we acquire users outside of the inner DotClique Slack space. These settings would just not do anything for them. 

We could implement this feature for Push Notifications also, but I think it is best to hide it for now, since we do not really need that feature for now. 

Depends on: https://github.com/mathiazom/rezervo/pull/22