### PR TITLE
fix(MobileConfigBtn): increase zIndex to be more than RippleBadge

### DIFF
--- a/src/components/configuration/MobileConfigUpdateBar.tsx
+++ b/src/components/configuration/MobileConfigUpdateBar.tsx
@@ -21,7 +21,7 @@ export default function MobileConfigUpdateBar({
     return (
         <Box
             sx={{
-                zIndex: 1,
+                zIndex: 2,
                 position: "fixed",
                 padding: "1.5rem",
                 bottom: 0,


### PR DESCRIPTION
## Before
<img width="304" alt="Screenshot 2023-09-19 at 15 07 11" src="https://github.com/mathiazom/rezervo-web/assets/26925695/8882b688-e06a-427b-a7f1-7fd20fd59461">

## After
<img width="304" alt="Screenshot 2023-09-19 at 15 08 23" src="https://github.com/mathiazom/rezervo-web/assets/26925695/feee7e51-b14b-4cd8-b856-647c2f92c0c3">