### PR TITLE
fix(WeekNavigator): reset weekOffset and weekNumber on integration switch

### DIFF
--- a/src/components/schedule/WeekNavigator.tsx
+++ b/src/components/schedule/WeekNavigator.tsx
@@ -33,6 +33,8 @@ export default function WeekNavigator({
     const [schedule, setSchedule] = useState<RezervoSchedule>(initialSchedule);
 
     useEffect(() => {
+        setWeekOffset(0);
+        setWeekNumber(getWeekNumber(initialSchedule[0]!));
         setSchedule(initialSchedule);
     }, [initialSchedule]);
 


### PR DESCRIPTION
Currently, the WeekNavigator maintains the old state for the week offset and week number when switching between integrations. This results in some weird behaviour when the user switches between integrations, while not being on the current week number. This PR resets the state in WeekNavigator completely when the integration is switched, so that it acts more natural.

## Before
https://github.com/mathiazom/rezervo-web/assets/26925695/a92135ef-7659-48c9-b5e5-7c0a1cad1c53

## After
https://github.com/mathiazom/rezervo-web/assets/26925695/a78d83a0-36f2-432f-830a-f078f0cf5218

