### PR TITLE
feat(schedule): hide instructor fields if no instructors are listed

### DIFF
--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -178,19 +178,21 @@ export default function ClassInfo({
                     {_class.location.room && _class.location.room.length > 0 ? `, ${_class.location.room}` : ""}
                 </Typography>
             </Box>
-            <Box
-                sx={{
-                    display: "flex",
-                    paddingTop: 1,
-                    gap: 1,
-                    alignItems: "center",
-                }}
-            >
-                <PersonRoundedIcon />
-                <Typography variant="body2" color="text.secondary">
-                    {_class.instructors.join(", ")}
-                </Typography>
-            </Box>
+            {_class.instructors.length > 0 && (
+                <Box
+                    sx={{
+                        display: "flex",
+                        paddingTop: 1,
+                        gap: 1,
+                        alignItems: "center",
+                    }}
+                >
+                    <PersonRoundedIcon />
+                    <Typography variant="body2" color="text.secondary">
+                        {_class.instructors.join(", ")}
+                    </Typography>
+                </Box>
+            )}
             {!_class.isBookable && !isClassInThePast(_class) && (
                 <Box
                     sx={{

--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -124,9 +124,11 @@ const ClassCard = ({
                     <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
                         {_class.location.studio}
                     </Typography>
-                    <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                        {_class.instructors.join(", ")}
-                    </Typography>
+                    {_class.instructors.length > 0 && (
+                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                            {_class.instructors.join(", ")}
+                        </Typography>
+                    )}
                 </CardContent>
                 <CardActions sx={{ padding: 0, zIndex: 1, position: "relative" }} disableSpacing>
                     <Box px={1.75} pt={0.5} pb={2} sx={{ width: "100%" }}>

--- a/src/lib/providers/brpsystems/adapters.ts
+++ b/src/lib/providers/brpsystems/adapters.ts
@@ -26,7 +26,7 @@ function brpToRezervoClass(brpClass: DetailedBrpClass): RezervoClass {
             description: brpClass.description,
             image: brpClass.image,
         },
-        instructors: brpClass.instructors.map((instructor) => instructor.name),
+        instructors: brpClass.instructors.map((instructor) => instructor.name) || [],
         startTime: LocalizedDateTime.fromISO(brpClass.duration.start),
         endTime: LocalizedDateTime.fromISO(brpClass.duration.end),
     };

--- a/src/lib/providers/ibooking/adapters.ts
+++ b/src/lib/providers/ibooking/adapters.ts
@@ -24,7 +24,7 @@ function iBookingToRezervoClass(iBookingClass: IBookingClass): RezervoClass {
             color: iBookingClass.color,
             image: iBookingClass.image,
         },
-        instructors: iBookingClass.instructors.map((iBookingInstructor) => iBookingInstructor.name),
+        instructors: iBookingClass.instructors.map((iBookingInstructor) => iBookingInstructor.name) || [],
     };
 }
 


### PR DESCRIPTION
When there are no instructors, the field in the class info modal should be hidden. 