### PR TITLE
Improve User Feedback

### DIFF
--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -178,7 +178,7 @@ function Chain({
             <ChainUserSettingsModal
                 open={isChainUserSettingsOpen}
                 setOpen={setIsChainUserSettingsOpen}
-                chain={chainProfile.identifier}
+                chainProfile={chainProfile}
                 onSubmit={() => setIsChainUserSettingsOpen(false)}
             />
         </>

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -166,7 +166,6 @@ function Chain({
                 classes={classes}
                 onInfo={setClassInfoClass}
                 onUpdateConfig={onUpdateConfig}
-                chainProfile={chainProfile}
             />
             <SettingsModal
                 open={isSettingsOpen}

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -166,6 +166,7 @@ function Chain({
                 classes={classes}
                 onInfo={setClassInfoClass}
                 onUpdateConfig={onUpdateConfig}
+                chainProfile={chainProfile}
             />
             <SettingsModal
                 open={isSettingsOpen}

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -91,21 +91,25 @@ function ConfigBar({
                         >
                             <Tooltip title={`Min timeplan${userConfig?.active ? "" : " (pauset)"}`}>
                                 <Badge
+                                    onClick={() => onAgendaOpen()}
                                     invisible={userConfig?.active ?? true}
                                     overlap={"circular"}
-                                    anchorOrigin={{ vertical: "top", horizontal: "right" }}
+                                    anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
                                     badgeContent={
                                         <PauseCircleRounded
                                             fontSize={"small"}
                                             color={"disabled"}
                                             sx={{
+                                                cursor: "pointer",
                                                 backgroundColor: theme.palette.background.default,
                                                 borderRadius: "50%",
+                                                marginTop: "-0.5rem",
+                                                marginLeft: "-0.5rem",
                                             }}
                                         />
                                     }
                                 >
-                                    <IconButton onClick={() => onAgendaOpen()}>
+                                    <IconButton>
                                         {userConfig?.classes.length === 0 ? <CalendarToday /> : <CalendarMonth />}
                                     </IconButton>
                                 </Badge>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -139,7 +139,7 @@ function ConfigBar({
                 </Box>
             ) : (
                 <Box>
-                    <Button startIcon={<LoginIcon />} href={"/api/auth/login"}>
+                    <Button endIcon={<LoginIcon />} href={"/api/auth/login"}>
                         Logg inn
                     </Button>
                 </Box>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -53,7 +53,7 @@ function ConfigBar({
                 >
                     {chainUserMissing ? (
                         <Box>
-                            <Tooltip title={`Registrer ${chain}-medlemskap`}>
+                            <Tooltip title={`Koble til ${chain}-medlemskap`}>
                                 <IconButton onClick={() => onChainUserSettingsOpen()}>
                                     <RocketLaunchRounded />
                                 </IconButton>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -6,6 +6,7 @@ import LoginIcon from "@mui/icons-material/Login";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import { Avatar, Badge, Box, CircularProgress, Tooltip, useTheme } from "@mui/material";
+import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
 import React from "react";
 
@@ -135,11 +136,9 @@ function ConfigBar({
                 </Box>
             ) : (
                 <Box>
-                    <Tooltip title={"Logg inn"}>
-                        <IconButton color={"primary"} href={"/api/auth/login"}>
-                            <LoginIcon />
-                        </IconButton>
-                    </Tooltip>
+                    <Button startIcon={<LoginIcon />} href={"/api/auth/login"}>
+                        Logg inn
+                    </Button>
                 </Box>
             )}
         </>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -1,5 +1,5 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
-import { CalendarMonth, PauseCircleRounded, RocketLaunchRounded } from "@mui/icons-material";
+import { CalendarMonth, CalendarToday, PauseCircleRounded, RocketLaunchRounded } from "@mui/icons-material";
 import CloudOffRoundedIcon from "@mui/icons-material/CloudOffRounded";
 import ErrorRoundedIcon from "@mui/icons-material/ErrorRounded";
 import LoginIcon from "@mui/icons-material/Login";
@@ -106,7 +106,7 @@ function ConfigBar({
                                     }
                                 >
                                     <IconButton onClick={() => onAgendaOpen()}>
-                                        <CalendarMonth />
+                                        {userConfig?.classes.length === 0 ? <CalendarToday /> : <CalendarMonth />}
                                     </IconButton>
                                 </Badge>
                             </Tooltip>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -53,7 +53,7 @@ function ConfigBar({
                 >
                     {chainUserMissing ? (
                         <Box>
-                            <Tooltip title={`Konfigurer ${chain}-bruker`}>
+                            <Tooltip title={`Registrer ${chain}-medlemskap`}>
                                 <IconButton onClick={() => onChainUserSettingsOpen()}>
                                     <RocketLaunchRounded />
                                 </IconButton>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -89,10 +89,26 @@ function ConfigBar({
                                 alignItems: "center",
                             }}
                         >
-                            <Tooltip title={"Min timeplan"}>
-                                <IconButton onClick={() => onAgendaOpen()}>
-                                    <CalendarMonth />
-                                </IconButton>
+                            <Tooltip title={`Min timeplan${userConfig?.active ? "" : " (pauset)"}`}>
+                                <Badge
+                                    invisible={userConfig?.active ?? true}
+                                    overlap={"circular"}
+                                    anchorOrigin={{ vertical: "top", horizontal: "right" }}
+                                    badgeContent={
+                                        <PauseCircleRounded
+                                            fontSize={"small"}
+                                            color={"disabled"}
+                                            sx={{
+                                                backgroundColor: theme.palette.background.default,
+                                                borderRadius: "50%",
+                                            }}
+                                        />
+                                    }
+                                >
+                                    <IconButton onClick={() => onAgendaOpen()}>
+                                        <CalendarMonth />
+                                    </IconButton>
+                                </Badge>
                             </Tooltip>
                             <Tooltip title={"Innstillinger"}>
                                 <IconButton onClick={() => onSettingsOpen()}>
@@ -102,30 +118,17 @@ function ConfigBar({
                         </Box>
                     )}
                     {user.name && (
-                        <Tooltip title={`${user.name}${userConfig?.active ? "" : " (pauset)"}`}>
-                            <Badge
-                                invisible={userConfig?.active ?? true}
-                                overlap={"circular"}
-                                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                                badgeContent={
-                                    <PauseCircleRounded
-                                        fontSize={"small"}
-                                        color={"disabled"}
-                                        sx={{ backgroundColor: theme.palette.background.default, borderRadius: "50%" }}
-                                    />
-                                }
+                        <Tooltip title={user.name}>
+                            <Avatar
+                                sx={{
+                                    width: 32,
+                                    height: 32,
+                                    fontSize: 18,
+                                    backgroundColor: hexColorHash(user.name),
+                                }}
                             >
-                                <Avatar
-                                    sx={{
-                                        width: 32,
-                                        height: 32,
-                                        fontSize: 18,
-                                        backgroundColor: hexColorHash(user.name),
-                                    }}
-                                >
-                                    {user.name[0]}
-                                </Avatar>
-                            </Badge>
+                                {user.name[0]}
+                            </Avatar>
                         </Tooltip>
                     )}
                     <Tooltip title={"Logg ut"}>

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -86,8 +86,8 @@ export default function Agenda({
                     }
                 >
                     <AlertTitle>Utdatert timeplan</AlertTitle>
-                    En eller flere av timene i timeplanen din er ikke satt opp denne uka. Kontroller at timeplanen din
-                    stemmer overens med ukas gruppetimer.
+                    En eller flere av timene i planen din går ikke denne uka. Kontroller at planen din stemmer overens
+                    med ukas gruppetimer.
                 </Alert>
             )}
             {agendaClasses.length === 0 && (

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -123,7 +123,6 @@ export default function Agenda({
                                                     agendaClass={cls}
                                                     onDelete={onDelete}
                                                     onInfo={() => cls._class && onInfo(cls._class)}
-                                                    bookingActive={bookingActive}
                                                     // onSettings={() =>
                                                     //     setSettingsClass(_class)
                                                     // }

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -1,27 +1,25 @@
 import { CalendarToday, EventRepeat, PauseCircleRounded } from "@mui/icons-material";
-import { Alert, AlertTitle, Avatar, Box, Tooltip, Typography, useTheme } from "@mui/material";
+import { Alert, AlertTitle, Avatar, Box, Typography, useTheme } from "@mui/material";
 import React from "react";
 
 import AgendaClassItem, { AgendaClass } from "@/components/modals/Agenda/AgendaClassItem";
 import { getCapitalizedWeekdays } from "@/lib/helpers/date";
 import { classConfigRecurrentId } from "@/lib/helpers/recurrentId";
-import { useUserConfig } from "@/lib/hooks/useUserConfig";
-import { ChainProfile, RezervoClass } from "@/types/chain";
+import { RezervoClass } from "@/types/chain";
 import { ClassConfig } from "@/types/config";
 
 export default function Agenda({
     agendaClasses,
     onInfo,
     onDelete,
-    chainProfile,
+    bookingActive,
 }: {
     agendaClasses: AgendaClass[];
     onInfo: (c: RezervoClass) => void;
     onDelete: (cc: ClassConfig) => void;
-    chainProfile: ChainProfile;
+    bookingActive: boolean;
 }) {
     const theme = useTheme();
-    const { userConfig } = useUserConfig(chainProfile.identifier);
     const hasGhostClasses = agendaClasses.some((agendaClass) => agendaClass._class === undefined);
 
     // Establish sort order of config classes
@@ -55,11 +53,6 @@ export default function Agenda({
                 <Typography variant="h6" component="h2">
                     Min timeplan
                 </Typography>
-                <Tooltip title={chainProfile.name}>
-                    <Avatar sx={{ width: 22, height: 22 }} src={chainProfile.images.common.smallLogo ?? ""}>
-                        {chainProfile.identifier}
-                    </Avatar>
-                </Tooltip>
             </Box>
             <Typography
                 variant="body2"
@@ -71,14 +64,14 @@ export default function Agenda({
             >
                 Disse timene vil bli booket automatisk
             </Typography>
-            {userConfig?.active === false && (
+            {!bookingActive && (
                 <Alert severity={"info"} icon={<PauseCircleRounded />}>
                     <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
                     Du kan skru på automatisk booking i innstillinger, slik at timene i timeplanen blir booket
                     automatisk
                 </Alert>
             )}
-            {hasGhostClasses && userConfig?.active && (
+            {hasGhostClasses && bookingActive && (
                 <Alert
                     severity={"error"}
                     icon={
@@ -98,11 +91,7 @@ export default function Agenda({
                 </Alert>
             )}
             {agendaClasses.length === 0 && (
-                <Alert
-                    severity={"info"}
-                    sx={{ mt: userConfig?.active ? 4 : 1 }}
-                    icon={<CalendarToday fontSize={"small"} />}
-                >
+                <Alert severity={"info"} sx={{ mt: bookingActive ? 4 : 1 }} icon={<CalendarToday fontSize={"small"} />}>
                     <AlertTitle>Ingen timer planlagt</AlertTitle>
                     Trykk på <EventRepeat fontSize={"small"} sx={{ mb: -0.5 }} /> -ikonet i oversikten for å legge til
                     en time i timeplanen.
@@ -134,7 +123,7 @@ export default function Agenda({
                                                     agendaClass={cls}
                                                     onDelete={onDelete}
                                                     onInfo={() => cls._class && onInfo(cls._class)}
-                                                    bookingActive={userConfig?.active === true}
+                                                    bookingActive={bookingActive}
                                                     // onSettings={() =>
                                                     //     setSettingsClass(_class)
                                                     // }

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -1,21 +1,23 @@
 import { EventRepeat } from "@mui/icons-material";
-import { Alert, AlertTitle, Box, Typography, useTheme } from "@mui/material";
+import { Alert, AlertTitle, Avatar, Box, Tooltip, Typography, useTheme } from "@mui/material";
 import React from "react";
 
 import AgendaClassItem, { AgendaClass } from "@/components/modals/Agenda/AgendaClassItem";
 import { getCapitalizedWeekdays } from "@/lib/helpers/date";
 import { classConfigRecurrentId } from "@/lib/helpers/recurrentId";
-import { RezervoClass } from "@/types/chain";
+import { ChainProfile, RezervoClass } from "@/types/chain";
 import { ClassConfig } from "@/types/config";
 
 export default function Agenda({
     agendaClasses,
     onInfo,
     onDelete,
+    chainProfile,
 }: {
     agendaClasses: AgendaClass[];
     onInfo: (c: RezervoClass) => void;
     onDelete: (cc: ClassConfig) => void;
+    chainProfile: ChainProfile;
 }) {
     const theme = useTheme();
 
@@ -44,11 +46,17 @@ export default function Agenda({
                 sx={{
                     display: "flex",
                     alignItems: "center",
+                    justifyContent: "space-between",
                 }}
             >
                 <Typography variant="h6" component="h2">
                     Min timeplan
                 </Typography>
+                <Tooltip title={chainProfile.name}>
+                    <Avatar sx={{ width: 22, height: 22 }} src={chainProfile.images.common.smallLogo ?? ""}>
+                        {chainProfile.identifier}
+                    </Avatar>
+                </Tooltip>
             </Box>
             <Typography
                 variant="body2"

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -1,4 +1,4 @@
-import { EventRepeat, PauseCircleRounded } from "@mui/icons-material";
+import { CalendarToday, EventRepeat, PauseCircleRounded } from "@mui/icons-material";
 import { Alert, AlertTitle, Avatar, Box, Tooltip, Typography, useTheme } from "@mui/material";
 import React from "react";
 
@@ -78,7 +78,11 @@ export default function Agenda({
                 </Alert>
             )}
             {agendaClasses.length === 0 && (
-                <Alert severity={"info"} sx={{ mt: 4 }}>
+                <Alert
+                    severity={"info"}
+                    sx={{ mt: userConfig?.active ? 4 : 1 }}
+                    icon={<CalendarToday fontSize={"small"} />}
+                >
                     <AlertTitle>Ingen timer planlagt</AlertTitle>
                     Trykk på <EventRepeat fontSize={"small"} sx={{ mb: -0.5 }} /> -ikonet i oversikten for å legge til
                     en time i timeplanen.

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -22,6 +22,7 @@ export default function Agenda({
 }) {
     const theme = useTheme();
     const { userConfig } = useUserConfig(chainProfile.identifier);
+    const hasGhostClasses = agendaClasses.some((agendaClass) => agendaClass._class === undefined);
 
     // Establish sort order of config classes
     const configTimeMinutes = (cc: ClassConfig) => cc.time.hour * 60 + cc.time.minute;
@@ -75,6 +76,25 @@ export default function Agenda({
                     <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
                     Du kan skru på automatisk booking i innstillinger, slik at timene i timeplanen blir booket
                     automatisk
+                </Alert>
+            )}
+            {hasGhostClasses && userConfig?.active && (
+                <Alert
+                    severity={"error"}
+                    icon={
+                        <Avatar
+                            alt={"Ghost class"}
+                            src={"/ghost.png"}
+                            sx={{
+                                width: 20,
+                                height: 20,
+                            }}
+                        />
+                    }
+                >
+                    <AlertTitle>Utdatert timeplan</AlertTitle>
+                    En eller flere av timene i timeplanen din er ikke satt opp denne uka. Kontroller at timeplanen din
+                    stemmer overens med ukas gruppetimer.
                 </Alert>
             )}
             {agendaClasses.length === 0 && (

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -37,10 +37,13 @@ export default function Agenda({
                 maxWidth: 500,
                 minHeight: 300,
                 transform: "translate(-50%, -50%)",
-                backgroundColor: theme.palette.background.paper,
                 borderRadius: "0.25em",
                 boxShadow: 24,
                 p: 4,
+                backgroundColor: "white",
+                '[data-mui-color-scheme="dark"] &': {
+                    backgroundColor: "#181818",
+                },
             }}
         >
             <Box
@@ -60,43 +63,51 @@ export default function Agenda({
                     color: theme.palette.grey[600],
                     fontSize: 15,
                 }}
-                mb={1}
+                mb={2.5}
             >
                 Disse timene vil bli booket automatisk
             </Typography>
-            {!bookingActive && (
-                <Alert severity={"info"} icon={<PauseCircleRounded />}>
-                    <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
-                    Du kan skru på automatisk booking i innstillinger, slik at timene i timeplanen blir booket
-                    automatisk
-                </Alert>
-            )}
-            {hasGhostClasses && bookingActive && (
-                <Alert
-                    severity={"error"}
-                    icon={
-                        <Avatar
-                            alt={"Ghost class"}
-                            src={"/ghost.png"}
-                            sx={{
-                                width: 20,
-                                height: 20,
-                            }}
-                        />
-                    }
-                >
-                    <AlertTitle>Utdatert timeplan</AlertTitle>
-                    En eller flere av timene i planen din går ikke denne uka. Kontroller at planen din stemmer overens
-                    med ukas gruppetimer.
-                </Alert>
-            )}
-            {agendaClasses.length === 0 && (
-                <Alert severity={"info"} sx={{ mt: bookingActive ? 4 : 1 }} icon={<CalendarToday fontSize={"small"} />}>
-                    <AlertTitle>Ingen timer planlagt</AlertTitle>
-                    Trykk på <EventRepeat fontSize={"small"} sx={{ mb: -0.5 }} /> -ikonet i oversikten for å legge til
-                    en time i timeplanen.
-                </Alert>
-            )}
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 1.5,
+                }}
+            >
+                {!bookingActive && (
+                    <Alert severity={"info"} icon={<PauseCircleRounded />}>
+                        <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
+                        Du kan skru på automatisk booking i Innstillinger, slik at timene i timeplanen blir booket
+                        automatisk
+                    </Alert>
+                )}
+                {hasGhostClasses && bookingActive && (
+                    <Alert
+                        severity={"error"}
+                        icon={
+                            <Avatar
+                                alt={"Ghost class"}
+                                src={"/ghost.png"}
+                                sx={{
+                                    width: 20,
+                                    height: 20,
+                                }}
+                            />
+                        }
+                    >
+                        <AlertTitle>Utdatert timeplan</AlertTitle>
+                        En eller flere av timene i planen din går ikke denne uka. Kontroller at planen din stemmer
+                        overens med ukas gruppetimer.
+                    </Alert>
+                )}
+                {agendaClasses.length === 0 && (
+                    <Alert severity={"info"} icon={<CalendarToday fontSize={"small"} />}>
+                        <AlertTitle>Ingen timer planlagt</AlertTitle>
+                        Trykk på <EventRepeat fontSize={"small"} sx={{ mb: -0.5 }} /> -ikonet i oversikten for å legge
+                        til en time i timeplanen.
+                    </Alert>
+                )}
+            </Box>
             <Box pt={2}>
                 {[0, 1, 2, 3, 4, 5, 6].map((weekday) => {
                     const dayClasses = agendaClasses.filter((a) => a.config.weekday === weekday);

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -1,10 +1,11 @@
-import { EventRepeat } from "@mui/icons-material";
+import { EventRepeat, PauseCircleRounded } from "@mui/icons-material";
 import { Alert, AlertTitle, Avatar, Box, Tooltip, Typography, useTheme } from "@mui/material";
 import React from "react";
 
 import AgendaClassItem, { AgendaClass } from "@/components/modals/Agenda/AgendaClassItem";
 import { getCapitalizedWeekdays } from "@/lib/helpers/date";
 import { classConfigRecurrentId } from "@/lib/helpers/recurrentId";
+import { useUserConfig } from "@/lib/hooks/useUserConfig";
 import { ChainProfile, RezervoClass } from "@/types/chain";
 import { ClassConfig } from "@/types/config";
 
@@ -20,6 +21,7 @@ export default function Agenda({
     chainProfile: ChainProfile;
 }) {
     const theme = useTheme();
+    const { userConfig } = useUserConfig(chainProfile.identifier);
 
     // Establish sort order of config classes
     const configTimeMinutes = (cc: ClassConfig) => cc.time.hour * 60 + cc.time.minute;
@@ -68,6 +70,13 @@ export default function Agenda({
             >
                 Disse timene vil bli booket automatisk
             </Typography>
+            {userConfig?.active === false && (
+                <Alert severity={"info"} icon={<PauseCircleRounded />}>
+                    <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
+                    Du kan skru på automatisk booking i innstillinger, slik at timene i timeplanen blir booket
+                    automatisk
+                </Alert>
+            )}
             {agendaClasses.length === 0 && (
                 <Alert severity={"info"} sx={{ mt: 4 }}>
                     <AlertTitle>Ingen timer planlagt</AlertTitle>
@@ -101,6 +110,7 @@ export default function Agenda({
                                                     agendaClass={cls}
                                                     onDelete={onDelete}
                                                     onInfo={() => cls._class && onInfo(cls._class)}
+                                                    bookingActive={userConfig?.active === true}
                                                     // onSettings={() =>
                                                     //     setSettingsClass(_class)
                                                     // }

--- a/src/components/modals/Agenda/AgendaClassItem.tsx
+++ b/src/components/modals/Agenda/AgendaClassItem.tsx
@@ -16,10 +16,12 @@ export default function AgendaClassItem({
     agendaClass,
     onDelete,
     onInfo,
+    bookingActive,
 }: {
     agendaClass: AgendaClass;
     onDelete: (cc: ClassConfig) => void;
     onInfo: () => void;
+    bookingActive: boolean;
 }) {
     const theme = useTheme();
 
@@ -65,7 +67,7 @@ export default function AgendaClassItem({
                     alignItems: "center",
                     justifyContent: "space-between",
                     background:
-                        agendaClass._class === undefined
+                        agendaClass._class === undefined || !bookingActive
                             ? `repeating-linear-gradient(
                             -55deg,
                             ${theme.palette.background.default},
@@ -75,7 +77,15 @@ export default function AgendaClassItem({
                             : undefined,
                 }}
             >
-                <CardContent onClick={onInfo} className={"unselectable"} sx={{ paddingBottom: 2, flexGrow: 1 }}>
+                <CardContent
+                    onClick={onInfo}
+                    className={"unselectable"}
+                    sx={{
+                        paddingBottom: 2,
+                        flexGrow: 1,
+                        cursor: agendaClass._class === undefined ? "auto" : "pointer",
+                    }}
+                >
                     <Box
                         sx={{
                             display: "flex",

--- a/src/components/modals/Agenda/AgendaClassItem.tsx
+++ b/src/components/modals/Agenda/AgendaClassItem.tsx
@@ -110,7 +110,7 @@ export default function AgendaClassItem({
                             )}
                         </Box>
                         {agendaClass._class === undefined && (
-                            <Tooltip title={"Spøkelsestime"}>
+                            <Tooltip title={"Denne timen er ikke satt opp denne uka"}>
                                 <Avatar
                                     alt={"Ghost class"}
                                     src={"/ghost.png"}

--- a/src/components/modals/Agenda/AgendaClassItem.tsx
+++ b/src/components/modals/Agenda/AgendaClassItem.tsx
@@ -108,7 +108,7 @@ export default function AgendaClassItem({
                             )}
                         </Box>
                         {agendaClass._class === undefined && (
-                            <Tooltip title={"Denne timen er ikke satt opp denne uka"}>
+                            <Tooltip title={"Denne timen går ikke denne uka"}>
                                 <Avatar
                                     alt={"Ghost class"}
                                     src={"/ghost.png"}

--- a/src/components/modals/Agenda/AgendaClassItem.tsx
+++ b/src/components/modals/Agenda/AgendaClassItem.tsx
@@ -16,12 +16,10 @@ export default function AgendaClassItem({
     agendaClass,
     onDelete,
     onInfo,
-    bookingActive,
 }: {
     agendaClass: AgendaClass;
     onDelete: (cc: ClassConfig) => void;
     onInfo: () => void;
-    bookingActive: boolean;
 }) {
     const theme = useTheme();
 
@@ -67,7 +65,7 @@ export default function AgendaClassItem({
                     alignItems: "center",
                     justifyContent: "space-between",
                     background:
-                        agendaClass._class === undefined || !bookingActive
+                        agendaClass._class === undefined
                             ? `repeating-linear-gradient(
                             -55deg,
                             ${theme.palette.background.default},

--- a/src/components/modals/Agenda/AgendaModal.tsx
+++ b/src/components/modals/Agenda/AgendaModal.tsx
@@ -3,7 +3,7 @@ import React, { Dispatch, SetStateAction } from "react";
 
 import Agenda from "@/components/modals/Agenda/Agenda";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
-import { RezervoClass } from "@/types/chain";
+import { ChainProfile, RezervoClass } from "@/types/chain";
 import { ChainConfig } from "@/types/config";
 
 const AgendaModal = ({
@@ -13,6 +13,7 @@ const AgendaModal = ({
     classes,
     onInfo,
     onUpdateConfig,
+    chainProfile,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
@@ -20,6 +21,7 @@ const AgendaModal = ({
     classes: RezervoClass[];
     onInfo: Dispatch<SetStateAction<RezervoClass | null>>;
     onUpdateConfig: (classId: string, selected: boolean) => void;
+    chainProfile: ChainProfile;
 }) => {
     return (
         <Modal open={open} onClose={() => setOpen(false)}>
@@ -32,6 +34,7 @@ const AgendaModal = ({
                         }))}
                         onInfo={onInfo}
                         onDelete={(c) => onUpdateConfig(classConfigRecurrentId(c), false)}
+                        chainProfile={chainProfile}
                     />
                 )}
             </>

--- a/src/components/modals/Agenda/AgendaModal.tsx
+++ b/src/components/modals/Agenda/AgendaModal.tsx
@@ -3,7 +3,7 @@ import React, { Dispatch, SetStateAction } from "react";
 
 import Agenda from "@/components/modals/Agenda/Agenda";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
-import { ChainProfile, RezervoClass } from "@/types/chain";
+import { RezervoClass } from "@/types/chain";
 import { ChainConfig } from "@/types/config";
 
 const AgendaModal = ({
@@ -13,7 +13,6 @@ const AgendaModal = ({
     classes,
     onInfo,
     onUpdateConfig,
-    chainProfile,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
@@ -21,7 +20,6 @@ const AgendaModal = ({
     classes: RezervoClass[];
     onInfo: Dispatch<SetStateAction<RezervoClass | null>>;
     onUpdateConfig: (classId: string, selected: boolean) => void;
-    chainProfile: ChainProfile;
 }) => {
     return (
         <Modal open={open} onClose={() => setOpen(false)}>
@@ -34,7 +32,7 @@ const AgendaModal = ({
                         }))}
                         onInfo={onInfo}
                         onDelete={(c) => onUpdateConfig(classConfigRecurrentId(c), false)}
-                        chainProfile={chainProfile}
+                        bookingActive={userConfig?.active === true}
                     />
                 )}
             </>

--- a/src/components/modals/ChainUser/ChainUserSettings.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettings.tsx
@@ -35,10 +35,10 @@ export default function ChainUserSettings({
             </DialogTitle>
             <DialogContent>
                 <Typography variant={"h6"} textAlign={"center"} sx={{ mb: 1 }}>
-                    Registrer <b>{chainProfile.identifier}</b>-medlemskap
+                    Koble til <b>{chainProfile.identifier}</b>-medlemskap
                 </Typography>
                 <Typography variant={"subtitle2"} sx={{ opacity: 0.6, textAlign: "center" }}>
-                    Logg inn med <b>{chainProfile.name}</b>-brukeren din for å aktivere <b>rezervo</b>
+                    Logg inn med <b>{chainProfile.name}</b>-brukeren din knytte den til <b>rezervo</b>
                 </Typography>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "0.5rem" }}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>

--- a/src/components/modals/ChainUser/ChainUserSettings.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettings.tsx
@@ -38,7 +38,7 @@ export default function ChainUserSettings({
                     Koble til <b>{chainProfile.identifier}</b>-medlemskap
                 </Typography>
                 <Typography variant={"subtitle2"} sx={{ opacity: 0.6, textAlign: "center" }}>
-                    Logg inn med <b>{chainProfile.name}</b>-brukeren din knytte den til <b>rezervo</b>
+                    Logg inn med <b>{chainProfile.name}</b>-brukeren din for å koble den til <b>rezervo</b>
                 </Typography>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "0.5rem" }}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>

--- a/src/components/modals/ChainUser/ChainUserSettings.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettings.tsx
@@ -1,7 +1,7 @@
 import { PasswordRounded } from "@mui/icons-material";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
-import { Box, Button, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
+import { Box, Button, DialogActions, DialogContent, Typography, useMediaQuery, useTheme } from "@mui/material";
 import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
 
@@ -21,27 +21,39 @@ export default function ChainUserSettings({
     isSubmitting: boolean;
     onClose: () => void;
 }) {
+    const theme = useTheme();
+
     const { chainUser, chainUserMissing } = useChainUser(chainProfile.identifier);
 
     const [username, setUsername] = useState(chainUser?.username ?? "");
     const [password, setPassword] = useState("");
 
+    const shortDevice = useMediaQuery("(max-height: 380px)");
+
     return (
         <>
-            <DialogTitle>
-                <Box sx={{ height: 50 }}>
+            <DialogContent
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 0.5,
+                    marginTop: 1,
+                }}
+            >
+                <Box sx={{ height: 50, flexShrink: 0, marginY: 2, display: shortDevice ? "none" : undefined }}>
                     <ChainLogo chainProfile={chainProfile} />
                 </Box>
-            </DialogTitle>
-            <DialogContent>
-                <Typography variant={"h6"} textAlign={"center"} sx={{ mb: 1 }}>
-                    Koble til <b>{chainProfile.identifier}</b>-medlemskap
+                <Typography variant={"h6"} textAlign={"center"}>
+                    Koble til <b>{chainProfile.identifier.toUpperCase()}</b>-medlemskap
                 </Typography>
-                <Typography variant={"subtitle2"} sx={{ opacity: 0.6, textAlign: "center" }}>
-                    Logg inn med <b>{chainProfile.name}</b>-brukeren din for å koble den til <b>rezervo</b>
+                <Typography
+                    variant={"subtitle2"}
+                    sx={{ color: theme.palette.grey[600], textAlign: "center", maxWidth: "18rem", margin: "0 auto" }}
+                >
+                    Logg inn med brukeren din fra <b>{chainProfile.name}</b> for å koble den til <b>rezervo</b>
                 </Typography>
-                <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "0.5rem" }}>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+                <Box sx={{ display: "flex", flexDirection: "column", gap: 2, marginTop: "2rem" }}>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 2 }}>
                         <PersonRoundedIcon />
                         <TextField
                             sx={{ width: "100%" }}

--- a/src/components/modals/ChainUser/ChainUserSettings.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettings.tsx
@@ -1,34 +1,45 @@
 import { PasswordRounded } from "@mui/icons-material";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
-import { Box, Button, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import { Box, Button, DialogActions, DialogContent, DialogTitle, Typography } from "@mui/material";
 import TextField from "@mui/material/TextField";
 import React, { useState } from "react";
 
-import { ChainIdentifier } from "@/lib/activeChains";
+import ChainLogo from "@/components/utils/ChainLogo";
 import { useChainUser } from "@/lib/hooks/useChainUser";
+import { ChainProfile } from "@/types/chain";
 import { ChainUserPayload } from "@/types/config";
 
 export default function ChainUserSettings({
-    chain,
+    chainProfile,
     submit,
     isSubmitting,
     onClose,
 }: {
-    chain: ChainIdentifier;
+    chainProfile: ChainProfile;
     submit: (payload: ChainUserPayload) => void;
     isSubmitting: boolean;
     onClose: () => void;
 }) {
-    const { chainUser, chainUserMissing } = useChainUser(chain);
+    const { chainUser, chainUserMissing } = useChainUser(chainProfile.identifier);
 
     const [username, setUsername] = useState(chainUser?.username ?? "");
     const [password, setPassword] = useState("");
 
     return (
         <>
-            <DialogTitle>Konfigurer {chain}-bruker</DialogTitle>
+            <DialogTitle>
+                <Box sx={{ height: 50 }}>
+                    <ChainLogo chainProfile={chainProfile} />
+                </Box>
+            </DialogTitle>
             <DialogContent>
+                <Typography variant={"h6"} textAlign={"center"} sx={{ mb: 1 }}>
+                    Registrer <b>{chainProfile.identifier}</b>-medlemskap
+                </Typography>
+                <Typography variant={"subtitle2"} sx={{ opacity: 0.6, textAlign: "center" }}>
+                    Logg inn med <b>{chainProfile.name}</b>-brukeren din for å aktivere <b>rezervo</b>
+                </Typography>
                 <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem", marginTop: "0.5rem" }}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: "1rem" }}>
                         <PersonRoundedIcon />
@@ -76,7 +87,7 @@ export default function ChainUserSettings({
                         })
                     }
                 >
-                    Lagre
+                    Logg inn
                 </LoadingButton>
             </DialogActions>
         </>

--- a/src/components/modals/ChainUser/ChainUserSettingsModal.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettingsModal.tsx
@@ -2,22 +2,22 @@ import { Dialog } from "@mui/material";
 import React, { Dispatch, SetStateAction } from "react";
 
 import ChainUserSettings from "@/components/modals/ChainUser/ChainUserSettings";
-import { ChainIdentifier } from "@/lib/activeChains";
 import { useChainUser } from "@/lib/hooks/useChainUser";
+import { ChainProfile } from "@/types/chain";
 import { ChainUserPayload } from "@/types/config";
 
 const ChainUserSettingsModal = ({
     open,
     setOpen,
-    chain,
+    chainProfile,
     onSubmit,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
-    chain: ChainIdentifier;
+    chainProfile: ChainProfile;
     onSubmit: () => void;
 }) => {
-    const { putChainUser, putChainUserIsMutating } = useChainUser(chain);
+    const { putChainUser, putChainUserIsMutating } = useChainUser(chainProfile.identifier);
 
     function submit(payload: ChainUserPayload) {
         putChainUser(payload).then(() => {
@@ -37,7 +37,7 @@ const ChainUserSettingsModal = ({
             fullWidth={true}
         >
             <ChainUserSettings
-                chain={chain}
+                chainProfile={chainProfile}
                 submit={submit}
                 isSubmitting={putChainUserIsMutating}
                 onClose={() => setOpen(false)}

--- a/src/components/modals/ChainUser/ChainUserSettingsModal.tsx
+++ b/src/components/modals/ChainUser/ChainUserSettingsModal.tsx
@@ -35,6 +35,14 @@ const ChainUserSettingsModal = ({
             }}
             maxWidth={"xs"}
             fullWidth={true}
+            PaperProps={{
+                sx: {
+                    backgroundColor: "white",
+                    '[data-mui-color-scheme="dark"] &': {
+                        backgroundColor: "#181818",
+                    },
+                },
+            }}
         >
             <ChainUserSettings
                 chainProfile={chainProfile}

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -345,9 +345,9 @@ export default function ClassInfo({
                     <AlertTitle>
                         Koble til <b>{chain}</b>-medlemskap
                     </AlertTitle>
-                    Du må tilknytte <b>{chain}</b>-medlemskapet til <b>rezervo</b> for å kunne booke eller legge til
-                    timer i timeplanen. Trykk på rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} />{" "}
-                    øverst til høyre for å logge inn med {chain}
+                    Du må koble <b>{chain}</b>-medlemskapet til <b>rezervo</b> for å kunne booke eller legge til timer i
+                    timeplanen. Trykk på rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til
+                    høyre for å logge inn med {chain}
                     -brukeren din.
                 </Alert>
             )}

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -355,16 +355,24 @@ export default function ClassInfo({
                 </Box>
             )}
             <Typography pt={2}>{_class.activity.description}</Typography>
-            {user === undefined && !isInThePast && (
-                <Alert severity="info" sx={{ mt: 1 }}>
-                    Du må logge inn for å kunne booke eller legge til timer i timeplanen
-                </Alert>
-            )}
-            {user !== undefined && userConfig === undefined && !isInThePast && (
-                <Alert severity="info" sx={{ mt: 1 }}>
-                    Du må konfigurere en {chain}-bruker for å booke eller legge til en time i timeplanen
-                </Alert>
-            )}
+
+            <Box
+                sx={{
+                    position: "sticky",
+                    bottom: 0,
+                }}
+            >
+                {user === undefined && !isInThePast && (
+                    <Alert severity="info" sx={{ mt: 1 }}>
+                        Du må logge inn for å kunne booke eller legge til timer i timeplanen
+                    </Alert>
+                )}
+                {user !== undefined && userConfig === undefined && !isInThePast && (
+                    <Alert severity="info" sx={{ mt: 1 }}>
+                        Du må konfigurere en {chain}-bruker for å booke eller legge til en time i timeplanen
+                    </Alert>
+                )}
+            </Box>
             {user && userConfig != undefined && !userConfigLoading && !userConfigError && !isInThePast && (
                 <>
                     {selfBooked || selfOnWaitlist ? (

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -336,19 +336,18 @@ export default function ClassInfo({
                 </Box>
             )}
             {user === undefined && !isInThePast && (
-                <Alert severity="info" sx={{ mt: 1 }} icon={<Login fontSize={"small"} />}>
+                <Alert severity="info" sx={{ mt: 1.5 }} icon={<Login fontSize={"small"} />}>
                     Du må logge inn for å kunne booke eller legge til timer i timeplanen
                 </Alert>
             )}
             {user !== undefined && userConfig === undefined && !isInThePast && (
-                <Alert severity="info" sx={{ mt: 1 }}>
+                <Alert severity="info" sx={{ mt: 1.5 }}>
                     <AlertTitle>
-                        Koble til <b>{chain}</b>-medlemskap
+                        Koble til <b>{chain.toUpperCase()}</b>-medlemskap
                     </AlertTitle>
-                    Du må koble <b>{chain}</b>-medlemskapet til <b>rezervo</b> for å kunne booke eller legge til timer i
-                    timeplanen. Trykk på rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til
-                    høyre for å logge inn med {chain}
-                    -brukeren din.
+                    Du må koble <b>{chain.toUpperCase()}</b>-medlemskapet til <b>rezervo</b> for å kunne booke eller
+                    legge til timer i timeplanen. Trykk på rakettsymbolet{" "}
+                    <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til høyre for å koble til.
                 </Alert>
             )}
             {_class.activity.image && (

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -354,6 +354,16 @@ export default function ClassInfo({
                 </Box>
             )}
             <Typography pt={2}>{_class.activity.description}</Typography>
+            {user === undefined && !isInThePast && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                    Du må logge inn for å kunne booke eller legge til timer i timeplanen
+                </Alert>
+            )}
+            {user !== undefined && userConfig === undefined && !isInThePast && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                    Du må konfigurere en {chain}-bruker for å booke eller legge til en time i timeplanen
+                </Alert>
+            )}
             {user && userConfig != undefined && !userConfigLoading && !userConfigError && !isInThePast && (
                 <>
                     {selfBooked || selfOnWaitlist ? (

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -7,13 +7,14 @@ import {
     EventBusy,
     EventRepeat,
     HourglassTop,
+    PauseCircleRounded,
 } from "@mui/icons-material";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import LocationOnRoundedIcon from "@mui/icons-material/LocationOnRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
-import { Alert, Box, Typography } from "@mui/material";
+import { Alert, AlertTitle, Box, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import Image from "next/image";
 import React, { useState } from "react";
@@ -411,12 +412,21 @@ export default function ClassInfo({
                             Legg til i timeplan
                         </Button>
                     )}
-                    {!_class.isBookable && (
-                        <Alert sx={{ mt: 1 }} severity="info">
-                            Booking for denne timen har ikke åpnet enda
-                            {classInUserConfig && ", men den vil bli booket automatisk når bookingen åpner"}
-                        </Alert>
-                    )}
+                    {!_class.isBookable &&
+                        (userConfig?.active === false && classInUserConfig ? (
+                            <Alert severity={"info"} sx={{ mt: 1 }} icon={<PauseCircleRounded />}>
+                                <AlertTitle>Automatisk booking er satt på pause</AlertTitle>
+                                Denne timen vil ikke bli booket automatisk. Du kan skru på automatisk booking i
+                                innstillinger, slik at timene i timeplanen blir booket automatisk
+                            </Alert>
+                        ) : (
+                            <Alert sx={{ mt: 1 }} severity="info">
+                                Booking for denne timen har ikke åpnet enda
+                                {classInUserConfig &&
+                                    userConfig?.active &&
+                                    ", men den vil bli booket automatisk når bookingen åpner"}
+                            </Alert>
+                        ))}
                 </>
             )}
             <ConfirmationDialog

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -343,11 +343,11 @@ export default function ClassInfo({
             {user !== undefined && userConfig === undefined && !isInThePast && (
                 <Alert severity="info" sx={{ mt: 1 }}>
                     <AlertTitle>
-                        Registrer ditt <b>{chain}</b>-medlemskap
+                        Koble til <b>{chain}</b>-medlemskap
                     </AlertTitle>
-                    Du må registrere medlemskapet ditt å kunne booke eller legge til timer i timeplanen. Trykk på
-                    rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til høyre for å logge
-                    inn med {chain}
+                    Du må tilknytte <b>{chain}</b>-medlemskapet til <b>rezervo</b> for å kunne booke eller legge til
+                    timer i timeplanen. Trykk på rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} />{" "}
+                    øverst til høyre for å logge inn med {chain}
                     -brukeren din.
                 </Alert>
             )}

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -7,7 +7,9 @@ import {
     EventBusy,
     EventRepeat,
     HourglassTop,
+    Login,
     PauseCircleRounded,
+    RocketLaunch,
 } from "@mui/icons-material";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
@@ -333,6 +335,22 @@ export default function ClassInfo({
                     </Typography>
                 </Box>
             )}
+            {user === undefined && !isInThePast && (
+                <Alert severity="info" sx={{ mt: 1 }} icon={<Login fontSize={"small"} />}>
+                    Du må logge inn for å kunne booke eller legge til timer i timeplanen
+                </Alert>
+            )}
+            {user !== undefined && userConfig === undefined && !isInThePast && (
+                <Alert severity="info" sx={{ mt: 1 }}>
+                    <AlertTitle>
+                        Registrer ditt <b>{chain}</b>-medlemskap
+                    </AlertTitle>
+                    Du må registrere medlemskapet ditt å kunne booke eller legge til timer i timeplanen. Trykk på
+                    rakettsymbolet <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til høyre for å logge
+                    inn med {chain}
+                    -brukeren din.
+                </Alert>
+            )}
             {_class.activity.image && (
                 <Box pt={2}>
                     <Image
@@ -355,24 +373,6 @@ export default function ClassInfo({
                 </Box>
             )}
             <Typography pt={2}>{_class.activity.description}</Typography>
-
-            <Box
-                sx={{
-                    position: "sticky",
-                    bottom: 0,
-                }}
-            >
-                {user === undefined && !isInThePast && (
-                    <Alert severity="info" sx={{ mt: 1 }}>
-                        Du må logge inn for å kunne booke eller legge til timer i timeplanen
-                    </Alert>
-                )}
-                {user !== undefined && userConfig === undefined && !isInThePast && (
-                    <Alert severity="info" sx={{ mt: 1 }}>
-                        Du må konfigurere en {chain}-bruker for å booke eller legge til en time i timeplanen
-                    </Alert>
-                )}
-            </Box>
             {user && userConfig != undefined && !userConfigLoading && !userConfigError && !isInThePast && (
                 <>
                     {selfBooked || selfOnWaitlist ? (


### PR DESCRIPTION
This PR does several small things to give the users better feedback about how they have configured the application and what to do in certain situations. I'm open to changing wording/severity etc

1. Make it more obvious that they are logged out. This is done by actually typing out "Logg inn" for the button, and by providing an alert in the class card. I think it makes sense to type out "Logg inn" here, but keep the small logout button. This is because we really want them to log in, not so much logout 😛 
<img width="1512" alt="Screenshot 2023-12-20 at 13 34 49" src="https://github.com/mathiazom/rezervo-web/assets/26925695/06ed359e-c037-4eff-abe0-1aaa7b044384">
<img width="622" alt="Screenshot 2023-12-20 at 13 34 03" src="https://github.com/mathiazom/rezervo-web/assets/26925695/a8cc1794-514e-4b6c-a80e-e1181a90d62c">

------------------------

2. Indicate that they need to set up a chain user in class info.
<img width="622" alt="Screenshot 2023-12-20 at 13 36 16" src="https://github.com/mathiazom/rezervo-web/assets/26925695/7ce4149e-c7d2-4ef4-850b-1aef573afae2">

------------------------

3. Indicate to the user that booking is inactive, and how to fix it
<img width="519" alt="Screenshot 2023-12-20 at 13 38 40" src="https://github.com/mathiazom/rezervo-web/assets/26925695/6a39598c-9a2e-4e8c-881d-f658d5e37cc5">
<img width="517" alt="Screenshot 2023-12-20 at 13 38 49" src="https://github.com/mathiazom/rezervo-web/assets/26925695/5c4b66b2-7829-4117-8bf2-25a3a537d69d">
<img width="629" alt="Screenshot 2023-12-20 at 13 38 22" src="https://github.com/mathiazom/rezervo-web/assets/26925695/401085b8-fd69-4501-8b1f-5c149c741c78">  

> I think it makes sense to indicate that booking has been paused in the class info since it might be a little subtle to notice the small pause icon on the agenda icon

<img width="269" alt="Screenshot 2023-12-20 at 13 37 15" src="https://github.com/mathiazom/rezervo-web/assets/26925695/d2ef8295-3809-4a65-b02d-310fc4d0f3dc">  

> Note that I moved the pause icon to the actual agenda icon, since that makes a lot more sense

------------------------
4. Finally, I added an alert for when the agenda is outdated
<img width="514" alt="Screenshot 2023-12-20 at 13 39 20" src="https://github.com/mathiazom/rezervo-web/assets/26925695/d93077c2-7888-485d-acbe-9b0d8ae3f1a5">

I also added a small chain logo in the agenda to indicate that the agenda only applies to _the current_ chain.