### PR TITLE
Display Special Event Information In BRP Class Descriptions

### DIFF
--- a/src/lib/helpers/activityCategorization.ts
+++ b/src/lib/helpers/activityCategorization.ts
@@ -77,7 +77,9 @@ const activityCategorization: RezervoCategory[] = [
     },
 ];
 
-export default function determineActivityCategory(activityName: string): RezervoCategory {
+export default function determineActivityCategory(activityName: string, isSpecial: boolean): RezervoCategory {
+    if (isSpecial) return activityCategorization[0]!;
+
     return (
         activityCategorization.find((category) =>
             category.keywords.some((keyword) => activityName.toLowerCase().includes(keyword)),

--- a/src/lib/providers/brpsystems/adapters.ts
+++ b/src/lib/providers/brpsystems/adapters.ts
@@ -4,7 +4,7 @@ import { DetailedBrpClass, DetailedBrpWeekSchedule } from "@/lib/providers/brpsy
 import { RezervoClass, RezervoDaySchedule, RezervoWeekSchedule } from "@/types/chain";
 
 function brpToRezervoClass(brpClass: DetailedBrpClass): RezervoClass {
-    const category = determineActivityCategory(brpClass.name);
+    const category = determineActivityCategory(brpClass.name, brpClass.externalMessage !== null);
     return {
         id: brpClass.id,
         location: {
@@ -24,7 +24,7 @@ function brpToRezervoClass(brpClass: DetailedBrpClass): RezervoClass {
             name: brpClass.groupActivityProduct.name.replace(/\s\(\d+\)$/, ""),
             category: category.name,
             color: category.color,
-            description: brpClass.description,
+            description: brpClass.externalMessage === null ? brpClass.description : brpClass.externalMessage,
             image: brpClass.image,
         },
         instructors: brpClass.instructors.map((instructor) => instructor.name) || [],


### PR DESCRIPTION
This PR modifies the adapter for BRPClasses so that the description is replaced by the `externalMessage` if present. This field is used for when there are events or special classes. I also categorize classes with this message as special, to make it visible in the WeekSchedule that something interesting is happening. 

I opted to _replace_ the class description with this information since the basic information usually does not matter when the class is a special occasion. I felt like including it in the description made it a bit unreadable (too much information). 

I also considered making a separate field in RezervoClass, but since Sit just puts special information in their descriptions, I felt it was clean to just put it there for BRP as well.

Here are some screenshots
<img width="421" alt="Screenshot 2023-12-23 at 17 54 07" src="https://github.com/mathiazom/rezervo-web/assets/26925695/d27e9f49-3212-4f53-b3af-b33902078a12">
<img width="631" alt="Screenshot 2023-12-23 at 17 54 58" src="https://github.com/mathiazom/rezervo-web/assets/26925695/65b711e1-60ce-46ce-b561-482eac33a168">
<img width="629" alt="Screenshot 2023-12-23 at 17 54 18" src="https://github.com/mathiazom/rezervo-web/assets/26925695/8b5bc4df-d7c2-4d25-8fd6-e23ed32e2bd8">


