### PR TITLE
Visualize Additional Class Information

### DIFF
--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -356,6 +356,11 @@ export default function ClassInfo({
                     <RocketLaunch fontSize={"small"} sx={{ mb: -0.7 }} /> øverst til høyre for å koble til.
                 </Alert>
             )}
+            {_class.activity.additionalInformation && (
+                <Alert sx={{ mt: 1.5 }} severity={"info"}>
+                    {_class.activity.additionalInformation}
+                </Alert>
+            )}
             {_class.activity.image && (
                 <Box pt={2}>
                     <Image

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -92,6 +92,7 @@ export type RezervoActivity = {
     name: string;
     category: string;
     description: string;
+    additionalInformation: string | null;
     color: string;
     image: string | null;
 };


### PR DESCRIPTION
This PR adds a small info banner to visualize any additional information about a class.

<img width="627" alt="Screenshot 2024-02-08 at 11 41 01" src="https://github.com/mathiazom/rezervo-web/assets/26925695/fae38de4-f1c2-4f58-8388-eb07379ea792">

Depends on https://github.com/mathiazom/rezervo/pull/36