### PR TITLE
Reduce ClassCard Size

### DIFF
--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -1,5 +1,5 @@
 import { CancelRounded, EventBusy, EventRepeat } from "@mui/icons-material";
-import { AvatarGroup, Badge, Box, Card, CardContent, Tooltip, Typography } from "@mui/material";
+import { AvatarGroup, Badge, Box, Card, CardContent, Collapse, Tooltip, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import React, { Fragment, useEffect, useState } from "react";
 
@@ -160,7 +160,7 @@ const ClassCard = ({
                                 {formatInstructorNames(_class.instructors)}
                             </Typography>
                         )}
-                        {showUsersPlanned && (
+                        <Collapse in={showUsersPlanned}>
                             <Box pl={0.75} pt={1}>
                                 <AvatarGroup
                                     max={4}
@@ -214,7 +214,7 @@ const ClassCard = ({
                                         ))}
                                 </AvatarGroup>
                             </Box>
-                        )}
+                        </Collapse>
                     </Box>
                     <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", ml: 0.5 }}>
                         {_class.isCancelled ? (

--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -44,6 +44,7 @@ const ClassCard = ({
     const [selectAnimation, setSelectAnimation] = useState<EnterLeaveAnimation | null>(
         selected ? randomElementFromArray(OVER_THE_TOP_ANIMATIONS) ?? null : null,
     );
+    const [showSelectClassTooltip, setShowSelectClassTooltip] = useState(false);
 
     useEffect(() => {
         if (selected) {
@@ -230,12 +231,20 @@ const ClassCard = ({
                             <ClassPopularityMeter _class={_class} historicPopularity={popularity} />
                         )}
                         {showScheduleAction && (
-                            <Tooltip title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}>
+                            <Tooltip
+                                title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}
+                                // Hide the tooltip when clicked
+                                open={showSelectClassTooltip}
+                                disableHoverListener
+                                onMouseEnter={() => setShowSelectClassTooltip(true)}
+                                onMouseLeave={() => setShowSelectClassTooltip(false)}
+                            >
                                 <IconButton
                                     onClick={(event) => {
                                         // Prevent onInfo()
                                         event.stopPropagation();
                                         selectClass();
+                                        setShowSelectClassTooltip(false);
                                     }}
                                     size={"small"}
                                     sx={{

--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -1,5 +1,5 @@
 import { CancelRounded, EventBusy, EventRepeat } from "@mui/icons-material";
-import { AvatarGroup, Badge, Box, Card, CardActions, CardContent, Tooltip, Typography } from "@mui/material";
+import { AvatarGroup, Badge, Box, Card, CardContent, Tooltip, Typography } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import React, { Fragment, useEffect, useState } from "react";
 
@@ -15,7 +15,7 @@ import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { randomElementFromArray } from "@/lib/utils/arrayUtils";
 import { hexWithOpacityToRgb } from "@/lib/utils/colorUtils";
 import { EnterLeaveAnimation, OVER_THE_TOP_ANIMATIONS } from "@/types/animation";
-import { RezervoClass } from "@/types/chain";
+import { RezervoClass, RezervoInstructor } from "@/types/chain";
 import { ClassPopularity } from "@/types/popularity";
 import { SessionStatus, StatusColors } from "@/types/userSessions";
 
@@ -55,6 +55,24 @@ const ClassCard = ({
         onUpdateConfig(!selected);
     }
 
+    const shortenMiddleNames = (name: string): string =>
+        name
+            .split(/\s+/)
+            .map((part, index, parts) =>
+                index > 0 && index < parts.length - 1 && part.length > 1 ? `${part.charAt(0).toUpperCase()}.` : part,
+            )
+            .join(" ");
+
+    function formatInstructorNames(instructors: RezervoInstructor[]): string {
+        const namesToShow = 2;
+        const formattedNames = instructors
+            .slice(0, namesToShow)
+            .map((instructor) => shortenMiddleNames(instructor.name))
+            .join(", ");
+
+        return formattedNames + (instructors.length > namesToShow ? `, +${instructors.length - namesToShow}` : "");
+    }
+
     const classColorRGB = (dark: boolean) =>
         `rgb(${hexWithOpacityToRgb(_class.activity.color, 0.6, dark ? 0 : 255).join(",")})`;
 
@@ -68,7 +86,6 @@ const ClassCard = ({
 
     const showScheduleAction = !isInThePast && selectable && !_class.isCancelled;
     const showUsersPlanned = userSessions.length > 0 || (!isInThePast && usersPlanned.length > 0);
-    const showActions = showScheduleAction || showUsersPlanned;
 
     return (
         <Card
@@ -111,9 +128,18 @@ const ClassCard = ({
                 <CardContent
                     className={"unselectable"}
                     onClick={onInfo}
-                    sx={{ paddingBottom: 1, zIndex: 1, position: "relative", cursor: "pointer" }}
+                    sx={{
+                        zIndex: 1,
+                        position: "relative",
+                        cursor: "pointer",
+                        display: "flex",
+                        justifyContent: "space-between",
+                        "&:last-child": {
+                            paddingBottom: 2,
+                        },
+                    }}
                 >
-                    <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+                    <Box>
                         <Typography
                             sx={{
                                 textDecoration: isInThePast || _class.isCancelled ? "line-through" : "none",
@@ -123,6 +149,74 @@ const ClassCard = ({
                         >
                             {_class.activity.name}
                         </Typography>
+                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                            {_class.startTime.toFormat("HH:mm")} - {_class.endTime.toFormat("HH:mm")}
+                        </Typography>
+                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                            {_class.location.studio}
+                        </Typography>
+                        {_class.instructors.length > 0 && (
+                            <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                                {formatInstructorNames(_class.instructors)}
+                            </Typography>
+                        )}
+                        {showUsersPlanned && (
+                            <Box pl={0.75} pt={1}>
+                                <AvatarGroup
+                                    max={4}
+                                    sx={{
+                                        justifyContent: "start",
+                                        marginLeft: "auto",
+                                        "& .MuiAvatar-root": {
+                                            width: 24,
+                                            height: 24,
+                                            fontSize: 12,
+                                            borderColor: "white",
+                                            '[data-mui-color-scheme="dark"] &': {
+                                                borderColor: "#191919",
+                                            },
+                                        },
+                                    }}
+                                >
+                                    {!isInThePast &&
+                                        usersPlanned.length > 0 &&
+                                        usersPlanned.map(({ user_name }) => (
+                                            <ClassUserAvatar
+                                                key={user_name}
+                                                username={user_name}
+                                                badgeIcon={
+                                                    _class.isBookable ? <PlannedNotBookedBadgeIcon /> : undefined
+                                                }
+                                                loading={userSessionsLoading}
+                                            />
+                                        ))}
+                                    {userSessions.length > 0 &&
+                                        userSessions.map(({ user_name, status }) => (
+                                            <Fragment key={user_name}>
+                                                <ClassUserAvatar
+                                                    username={user_name}
+                                                    invisibleBadge={isInThePast}
+                                                    badgeIcon={
+                                                        status === SessionStatus.NOSHOW ? (
+                                                            <NoShowBadgeIcon />
+                                                        ) : undefined
+                                                    }
+                                                    rippleColor={
+                                                        status === SessionStatus.BOOKED ||
+                                                        status === SessionStatus.CONFIRMED
+                                                            ? StatusColors.ACTIVE
+                                                            : status === SessionStatus.WAITLIST
+                                                              ? StatusColors.WAITLIST
+                                                              : undefined
+                                                    }
+                                                />
+                                            </Fragment>
+                                        ))}
+                                </AvatarGroup>
+                            </Box>
+                        )}
+                    </Box>
+                    <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", ml: 0.5 }}>
                         {_class.isCancelled ? (
                             <Tooltip title={"Timen er avlyst"}>
                                 <Badge
@@ -135,94 +229,26 @@ const ClassCard = ({
                         ) : (
                             <ClassPopularityMeter _class={_class} historicPopularity={popularity} />
                         )}
+                        {showScheduleAction && (
+                            <Tooltip title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}>
+                                <IconButton
+                                    onClick={(event) => {
+                                        // Prevent onInfo()
+                                        event.stopPropagation();
+                                        selectClass();
+                                    }}
+                                    size={"small"}
+                                    sx={{
+                                        padding: 0,
+                                        height: 28, // to avoid jumping when avatars are displayed
+                                    }}
+                                >
+                                    {selected ? <EventBusy /> : <EventRepeat />}
+                                </IconButton>
+                            </Tooltip>
+                        )}
                     </Box>
-                    <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                        {_class.startTime.toFormat("HH:mm")} - {_class.endTime.toFormat("HH:mm")}
-                    </Typography>
-                    <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                        {_class.location.studio}
-                    </Typography>
-                    {_class.instructors.length > 0 && (
-                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                            {_class.instructors.map((i) => i.name).join(", ")}
-                        </Typography>
-                    )}
                 </CardContent>
-                {showActions && (
-                    <CardActions sx={{ padding: 0, zIndex: 1, position: "relative" }} disableSpacing>
-                        <Box px={1.75} pt={0.5} pb={2} sx={{ width: "100%" }}>
-                            <Box sx={{ display: "flex" }}>
-                                {showScheduleAction && (
-                                    <Tooltip title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}>
-                                        <IconButton
-                                            onClick={selectClass}
-                                            size={"small"}
-                                            sx={{
-                                                padding: 0,
-                                                height: 28, // to avoid jumping when avatars are displayed
-                                            }}
-                                        >
-                                            {selected ? <EventBusy /> : <EventRepeat />}
-                                        </IconButton>
-                                    </Tooltip>
-                                )}
-                                {showUsersPlanned && (
-                                    <AvatarGroup
-                                        max={4}
-                                        sx={{
-                                            justifyContent: "start",
-                                            marginLeft: "auto",
-                                            "& .MuiAvatar-root": {
-                                                width: 24,
-                                                height: 24,
-                                                fontSize: 12,
-                                                borderColor: "white",
-                                                '[data-mui-color-scheme="dark"] &': {
-                                                    borderColor: "#191919",
-                                                },
-                                            },
-                                        }}
-                                    >
-                                        {!isInThePast &&
-                                            usersPlanned.length > 0 &&
-                                            usersPlanned.map(({ user_name }) => (
-                                                <ClassUserAvatar
-                                                    key={user_name}
-                                                    username={user_name}
-                                                    badgeIcon={
-                                                        _class.isBookable ? <PlannedNotBookedBadgeIcon /> : undefined
-                                                    }
-                                                    loading={userSessionsLoading}
-                                                />
-                                            ))}
-                                        {userSessions.length > 0 &&
-                                            userSessions.map(({ user_name, status }) => (
-                                                <Fragment key={user_name}>
-                                                    <ClassUserAvatar
-                                                        username={user_name}
-                                                        invisibleBadge={isInThePast}
-                                                        badgeIcon={
-                                                            status === SessionStatus.NOSHOW ? (
-                                                                <NoShowBadgeIcon />
-                                                            ) : undefined
-                                                        }
-                                                        rippleColor={
-                                                            status === SessionStatus.BOOKED ||
-                                                            status === SessionStatus.CONFIRMED
-                                                                ? StatusColors.ACTIVE
-                                                                : status === SessionStatus.WAITLIST
-                                                                  ? StatusColors.WAITLIST
-                                                                  : undefined
-                                                        }
-                                                    />
-                                                </Fragment>
-                                            ))}
-                                    </AvatarGroup>
-                                )}
-                            </Box>
-                        </Box>
-                    </CardActions>
-                )}
             </Box>
         </Card>
     );

--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -14,6 +14,7 @@ import { useUserConfig } from "@/lib/hooks/useUserConfig";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { randomElementFromArray } from "@/lib/utils/arrayUtils";
 import { hexWithOpacityToRgb } from "@/lib/utils/colorUtils";
+import { shortenMiddleNames } from "@/lib/utils/textUtils";
 import { EnterLeaveAnimation, OVER_THE_TOP_ANIMATIONS } from "@/types/animation";
 import { RezervoClass, RezervoInstructor } from "@/types/chain";
 import { ClassPopularity } from "@/types/popularity";
@@ -55,14 +56,6 @@ const ClassCard = ({
     function selectClass() {
         onUpdateConfig(!selected);
     }
-
-    const shortenMiddleNames = (name: string): string =>
-        name
-            .split(/\s+/)
-            .map((part, index, parts) =>
-                index > 0 && index < parts.length - 1 && part.length > 1 ? `${part.charAt(0).toUpperCase()}.` : part,
-            )
-            .join(" ");
 
     function formatInstructorNames(instructors: RezervoInstructor[]): string {
         const namesToShow = 2;

--- a/src/lib/utils/textUtils.ts
+++ b/src/lib/utils/textUtils.ts
@@ -1,0 +1,7 @@
+export const shortenMiddleNames = (name: string): string =>
+    name
+        .split(/\s+/)
+        .map((part, index, parts) =>
+            index > 0 && index < parts.length - 1 && part.length > 1 ? `${part.charAt(0).toUpperCase()}.` : part,
+        )
+        .join(" ");

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -50,6 +50,10 @@ export type RezervoLocation = {
     name: string;
 };
 
+export type RezervoInstructor = {
+    name: string;
+};
+
 export type RezervoSchedule = {
     [weekOffset: number]: RezervoWeekSchedule;
 };
@@ -78,9 +82,7 @@ export type RezervoClassBase = {
     availableSlots: number;
     waitingListCount: number | null;
     activity: RezervoActivity;
-    instructors: {
-        name: string;
-    }[];
+    instructors: RezervoInstructor[];
 };
 
 export type RezervoClass = RezervoClassBase & {


### PR DESCRIPTION
This PR aims to reduce the size of the ClassCard component to make it easier to view more classes at once. This is done by moving the `selectClass` button, so that it is always below the class popularity meter. In addition, I opted to shorten the instructor names, both in terms of how many names we display, as well as shortening their (sometimes chonky) middle names. 


A bit of motivation for this change:
- ClassCards on mobile take up way too much space and make the UI look clunky, not designed for mobile
- iBooking, BRP and Sats are all able to fit more classes into their view at the same time than us
- Minimize the UI difference between a logged in vs logged out user

With these changes, we fit on average 20% more classes into the view than we do today. On mobile that equates to roughly 1 extra class per day. The new design looks a bit busier at first glance, but I think the extra classes make up for it, especially on mobile.

## Before/After Mobile - Sit
<img width="390" alt="Screenshot 2024-02-24 at 09 44 11" src="https://github.com/mathiazom/rezervo-web/assets/26925695/3ada61b0-694e-4fd2-8997-abf6b539ccbc">
<img width="390" alt="Screenshot 2024-02-24 at 09 44 15" src="https://github.com/mathiazom/rezervo-web/assets/26925695/5d8dd545-6739-49b4-9a57-04f6158d30b2">

## Before/After Mobile - FSC
<img width="390" alt="Screenshot 2024-02-24 at 09 43 32" src="https://github.com/mathiazom/rezervo-web/assets/26925695/5657929b-45df-46d7-8221-3c23189d941a">
<img width="390" alt="Screenshot 2024-02-24 at 09 43 35" src="https://github.com/mathiazom/rezervo-web/assets/26925695/7fa9bc1d-5956-49d5-b738-11b8208239d5">


## Before - Sit
<img width="1512" alt="Screenshot 2024-02-24 at 09 14 37" src="https://github.com/mathiazom/rezervo-web/assets/26925695/6d5ddf71-277d-4698-8353-efc73583a6a8">

## After - Sit
<img width="1512" alt="Screenshot 2024-02-24 at 09 14 44" src="https://github.com/mathiazom/rezervo-web/assets/26925695/26455b1a-d707-472e-9bab-039d884b11e1">

## Before - FSC
<img width="1512" alt="Screenshot 2024-02-24 at 09 18 00" src="https://github.com/mathiazom/rezervo-web/assets/26925695/ec8e5207-fe56-49dd-bad4-105a8de8c701">

## After - FSC
<img width="1512" alt="Screenshot 2024-02-24 at 09 17 46" src="https://github.com/mathiazom/rezervo-web/assets/26925695/adcc110d-f96c-483f-a700-afb18c6f3070">