### PR TITLE
feat(Community): add confirmation dialog when removing friends

### DIFF
--- a/src/components/modals/Community/Community.tsx
+++ b/src/components/modals/Community/Community.tsx
@@ -20,7 +20,7 @@ const CommunityUserList = ({
     defaultText: string;
     communityUsers: CommunityUser[];
     chainProfiles: ChainProfile[];
-    onRemoveFriend: (communityUser: CommunityUser) => void;
+    onRemoveFriend?: (communityUser: CommunityUser) => void;
     badge?: ReactNode;
 }) => {
     return (
@@ -63,7 +63,6 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                 defaultText={"Du har ingen ubesvarte venneforespørsler"}
                 communityUsers={friendRequests}
                 chainProfiles={chainProfiles}
-                onRemoveFriend={() => {}}
                 badge={
                     friendRequests.length > 0 && (
                         <Tooltip title={`Du har ${friendRequests.length} ubesvarte venneforespørsler`}>
@@ -154,7 +153,6 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                                     ) ?? []
                                 }
                                 chainProfiles={chainProfiles}
-                                onRemoveFriend={() => {}}
                             />
                             {friendRequests.length === 0 && <FriendRequests />}
                         </>

--- a/src/components/modals/Community/Community.tsx
+++ b/src/components/modals/Community/Community.tsx
@@ -1,26 +1,23 @@
 import { People } from "@mui/icons-material";
 import { Alert, Badge, Box, Divider, Tooltip, Typography, useTheme } from "@mui/material";
-import React, { ReactNode, useState } from "react";
+import React, { ReactNode } from "react";
 
 import CommunityUserCard from "@/components/modals/Community/CommunityUserCard";
-import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { ChainProfile } from "@/types/chain";
-import { CommunityUser, UserRelationship, UserRelationshipAction } from "@/types/community";
+import { CommunityUser, UserRelationship } from "@/types/community";
 
 const CommunityUserList = ({
     title,
     defaultText,
     communityUsers,
     chainProfiles,
-    onRemoveFriend,
     badge,
 }: {
     title: string;
     defaultText: string;
     communityUsers: CommunityUser[];
     chainProfiles: ChainProfile[];
-    onRemoveFriend?: (communityUser: CommunityUser) => void;
     badge?: ReactNode;
 }) => {
     return (
@@ -38,21 +35,15 @@ const CommunityUserList = ({
             )}
             {communityUsers.length > 0 && <Divider sx={{ mt: 1 }} />}
             {communityUsers.map((cu) => (
-                <CommunityUserCard
-                    key={cu.name}
-                    communityUser={cu}
-                    chainProfiles={chainProfiles}
-                    onRemoveFriend={onRemoveFriend}
-                />
+                <CommunityUserCard key={cu.name} communityUser={cu} chainProfiles={chainProfiles} />
             ))}
         </Box>
     );
 };
 
 const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
-    const { community, communityLoading, communityError, updateRelationship } = useCommunity();
+    const { community, communityLoading, communityError } = useCommunity();
     const theme = useTheme();
-    const [friendUpForRemoval, setFriendUpForRemoval] = useState<CommunityUser | null>(null);
 
     const friendRequests =
         community?.users.filter((user) => user.relationship === UserRelationship.REQUEST_RECEIVED) ?? [];
@@ -138,9 +129,6 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                                     []
                                 }
                                 chainProfiles={chainProfiles}
-                                onRemoveFriend={(communityUser) => {
-                                    setFriendUpForRemoval(communityUser);
-                                }}
                             />
                             <CommunityUserList
                                 title={"Personer du kanskje kjenner"}
@@ -157,29 +145,6 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                             {friendRequests.length === 0 && <FriendRequests />}
                         </>
                     )}
-                    <ConfirmationDialog
-                        open={friendUpForRemoval !== null}
-                        title={`Fjerne venn?`}
-                        description={
-                            <>
-                                <Typography>
-                                    Du er i ferd med å fjerne <b>{friendUpForRemoval?.name}</b> som venn.
-                                </Typography>
-                                <Typography>Dette kan ikke angres!</Typography>
-                            </>
-                        }
-                        confirmText={"Fjern venn"}
-                        onCancel={() => setFriendUpForRemoval(null)}
-                        onConfirm={() => {
-                            if (friendUpForRemoval !== null) {
-                                updateRelationship({
-                                    userId: friendUpForRemoval.userId,
-                                    action: UserRelationshipAction.REMOVE_FRIEND,
-                                });
-                            }
-                            setFriendUpForRemoval(null);
-                        }}
-                    />
                 </Box>
             )}
         </Box>

--- a/src/components/modals/Community/CommunityUserCard.tsx
+++ b/src/components/modals/Community/CommunityUserCard.tsx
@@ -12,9 +12,11 @@ import { CommunityUser, UserRelationship, UserRelationshipAction } from "@/types
 const CommunityUserCard = ({
     communityUser,
     chainProfiles,
+    onRemoveFriend,
 }: {
     communityUser: CommunityUser;
     chainProfiles: ChainProfile[];
+    onRemoveFriend: (communityUser: CommunityUser) => void;
 }) => {
     const { communityLoading, updateRelationship, isUpdatingRelationship } = useCommunity();
     const updateUserRelationship = (action: UserRelationshipAction) => {
@@ -34,7 +36,7 @@ const CommunityUserCard = ({
                         loading={isLoading}
                         startIcon={<PersonRemove />}
                         color={"error"}
-                        onClick={() => updateUserRelationship(UserRelationshipAction.REMOVE_FRIEND)}
+                        onClick={() => onRemoveFriend(communityUser)}
                     >
                         Fjern venn
                     </LoadingButton>

--- a/src/components/modals/Community/CommunityUserCard.tsx
+++ b/src/components/modals/Community/CommunityUserCard.tsx
@@ -2,8 +2,9 @@ import { PersonAdd, PersonRemove } from "@mui/icons-material";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { Avatar, Box, CircularProgress, TableCell, TableRow, Tooltip, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
-import React from "react";
+import React, { useState } from "react";
 
+import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { hexColorHash } from "@/lib/utils/colorUtils";
 import { ChainProfile } from "@/types/chain";
@@ -12,13 +13,15 @@ import { CommunityUser, UserRelationship, UserRelationshipAction } from "@/types
 const CommunityUserCard = ({
     communityUser,
     chainProfiles,
-    onRemoveFriend,
 }: {
     communityUser: CommunityUser;
     chainProfiles: ChainProfile[];
-    onRemoveFriend: ((communityUser: CommunityUser) => void) | undefined;
 }) => {
     const { communityLoading, updateRelationship, isUpdatingRelationship } = useCommunity();
+    const [confirmDialogState, setConfirmDialogState] = useState<
+        UserRelationshipAction.REMOVE_FRIEND | UserRelationshipAction.DENY_FRIEND | null
+    >(null);
+
     const updateUserRelationship = (action: UserRelationshipAction) => {
         return updateRelationship({
             userId: communityUser.userId,
@@ -36,7 +39,7 @@ const CommunityUserCard = ({
                         loading={isLoading}
                         startIcon={<PersonRemove />}
                         color={"error"}
-                        onClick={() => onRemoveFriend !== undefined && onRemoveFriend(communityUser)}
+                        onClick={() => setConfirmDialogState(UserRelationshipAction.REMOVE_FRIEND)}
                     >
                         Fjern venn
                     </LoadingButton>
@@ -55,7 +58,7 @@ const CommunityUserCard = ({
                                 <Button
                                     startIcon={<PersonRemove />}
                                     color={"error"}
-                                    onClick={() => updateUserRelationship(UserRelationshipAction.DENY_FRIEND)}
+                                    onClick={() => setConfirmDialogState(UserRelationshipAction.DENY_FRIEND)}
                                 >
                                     Avslå
                                 </Button>
@@ -90,52 +93,104 @@ const CommunityUserCard = ({
     };
 
     return (
-        <TableRow sx={{ display: "flex" }}>
-            <TableCell
-                sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", width: "100%", px: 0 }}
-            >
-                <Box sx={{ display: "flex", alignItems: "center" }}>
-                    <Avatar
-                        alt={communityUser.name}
-                        sx={{
-                            backgroundColor: hexColorHash(communityUser.name),
-                            width: 36,
-                            height: 36,
-                            fontSize: 18,
-                            mr: 1.5,
-                        }}
-                    >
-                        {communityUser.name[0]}
-                    </Avatar>
-                    <Box>
-                        <Typography variant={"subtitle2"} fontWeight={"bold"}>
-                            {communityUser.name}
-                        </Typography>
-                        <Box sx={{ display: "flex", gap: 0.5 }}>
-                            {communityUser.chains
-                                .sort((a, b) => a.localeCompare(b))
-                                .map((chain) => {
-                                    const chainProfile = chainProfiles.find(
-                                        (chainProfile) => chainProfile.identifier === chain,
-                                    );
-                                    if (chainProfile === undefined) return <></>;
-                                    return (
-                                        <Tooltip title={chainProfile.name} key={chain}>
-                                            <Avatar
-                                                sx={{ width: 16, height: 16 }}
-                                                src={chainProfile.images.common.smallLogo ?? ""}
-                                            >
-                                                {chain}
-                                            </Avatar>
-                                        </Tooltip>
-                                    );
-                                })}
+        <>
+            <TableRow sx={{ display: "flex" }}>
+                <TableCell
+                    sx={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        width: "100%",
+                        px: 0,
+                    }}
+                >
+                    <Box sx={{ display: "flex", alignItems: "center" }}>
+                        <Avatar
+                            alt={communityUser.name}
+                            sx={{
+                                backgroundColor: hexColorHash(communityUser.name),
+                                width: 36,
+                                height: 36,
+                                fontSize: 18,
+                                mr: 1.5,
+                            }}
+                        >
+                            {communityUser.name[0]}
+                        </Avatar>
+                        <Box>
+                            <Typography variant={"subtitle2"} fontWeight={"bold"}>
+                                {communityUser.name}
+                            </Typography>
+                            <Box sx={{ display: "flex", gap: 0.5 }}>
+                                {communityUser.chains
+                                    .sort((a, b) => a.localeCompare(b))
+                                    .map((chain) => {
+                                        const chainProfile = chainProfiles.find(
+                                            (chainProfile) => chainProfile.identifier === chain,
+                                        );
+                                        if (chainProfile === undefined) return <></>;
+                                        return (
+                                            <Tooltip title={chainProfile.name} key={chain}>
+                                                <Avatar
+                                                    sx={{ width: 16, height: 16 }}
+                                                    src={chainProfile.images.common.smallLogo ?? ""}
+                                                >
+                                                    {chain}
+                                                </Avatar>
+                                            </Tooltip>
+                                        );
+                                    })}
+                            </Box>
                         </Box>
                     </Box>
-                </Box>
-                {renderRelationshipActions(communityUser.relationship)}
-            </TableCell>
-        </TableRow>
+                    {renderRelationshipActions(communityUser.relationship)}
+                </TableCell>
+            </TableRow>
+            {confirmDialogState !== null &&
+                (confirmDialogState === UserRelationshipAction.REMOVE_FRIEND ? (
+                    <ConfirmationDialog
+                        open={true}
+                        title={"Fjerne venn?"}
+                        description={
+                            <>
+                                <Typography>
+                                    Du er i ferd med å fjerne <b>{communityUser.name}</b> som venn.
+                                </Typography>
+                                <Typography>Dette kan ikke angres!</Typography>
+                            </>
+                        }
+                        confirmText={"Fjern venn"}
+                        onCancel={() => setConfirmDialogState(null)}
+                        onConfirm={() => {
+                            if (confirmDialogState !== null) {
+                                updateUserRelationship(confirmDialogState);
+                            }
+                            setConfirmDialogState(null);
+                        }}
+                    />
+                ) : (
+                    <ConfirmationDialog
+                        open={true}
+                        title={"Avslå venenforespørsel?"}
+                        description={
+                            <>
+                                <Typography>
+                                    Du er i ferd med å avslå <b>{communityUser.name}</b> sin venneforespørsel.
+                                </Typography>
+                                <Typography>Dette kan ikke angres!</Typography>
+                            </>
+                        }
+                        confirmText={"Avslå forespørsel"}
+                        onCancel={() => setConfirmDialogState(null)}
+                        onConfirm={() => {
+                            if (confirmDialogState !== null) {
+                                updateUserRelationship(confirmDialogState);
+                            }
+                            setConfirmDialogState(null);
+                        }}
+                    />
+                ))}
+        </>
     );
 };
 

--- a/src/components/modals/Community/CommunityUserCard.tsx
+++ b/src/components/modals/Community/CommunityUserCard.tsx
@@ -171,7 +171,7 @@ const CommunityUserCard = ({
                 ) : (
                     <ConfirmationDialog
                         open={true}
-                        title={"Avslå venenforespørsel?"}
+                        title={"Avslå venneforespørsel?"}
                         description={
                             <>
                                 <Typography>

--- a/src/components/modals/Community/CommunityUserCard.tsx
+++ b/src/components/modals/Community/CommunityUserCard.tsx
@@ -16,7 +16,7 @@ const CommunityUserCard = ({
 }: {
     communityUser: CommunityUser;
     chainProfiles: ChainProfile[];
-    onRemoveFriend: (communityUser: CommunityUser) => void;
+    onRemoveFriend: ((communityUser: CommunityUser) => void) | undefined;
 }) => {
     const { communityLoading, updateRelationship, isUpdatingRelationship } = useCommunity();
     const updateUserRelationship = (action: UserRelationshipAction) => {
@@ -36,7 +36,7 @@ const CommunityUserCard = ({
                         loading={isLoading}
                         startIcon={<PersonRemove />}
                         color={"error"}
-                        onClick={() => onRemoveFriend(communityUser)}
+                        onClick={() => onRemoveFriend !== undefined && onRemoveFriend(communityUser)}
                     >
                         Fjern venn
                     </LoadingButton>

--- a/src/components/utils/ConfirmationDialog.tsx
+++ b/src/components/utils/ConfirmationDialog.tsx
@@ -7,6 +7,16 @@ import DialogTitle from "@mui/material/DialogTitle";
 import * as React from "react";
 import { ReactNode } from "react";
 
+export type ConfirmationDialogProps = {
+    open: boolean;
+    title: string;
+    description: ReactNode;
+    confirmText: string;
+    cancelText?: string;
+    onCancel: () => void;
+    onConfirm: () => void;
+};
+
 export default function ConfirmationDialog({
     open,
     title,
@@ -15,15 +25,7 @@ export default function ConfirmationDialog({
     cancelText = "Avbryt",
     onCancel,
     onConfirm,
-}: {
-    open: boolean;
-    title: string;
-    description: ReactNode;
-    confirmText: string;
-    cancelText?: string;
-    onCancel: () => void;
-    onConfirm: () => void;
-}) {
+}: ConfirmationDialogProps) {
     return (
         <Dialog open={open} onClose={onCancel}>
             <DialogTitle>{title}</DialogTitle>


### PR DESCRIPTION
Removing friends is quite a destructive action, and thus there should be a confirmation dialog to prevent misclicks.

https://github.com/mathiazom/rezervo-web/assets/26925695/482ee2b7-b5ca-428a-90a9-5753da482150

