### PR TITLE
feat(logout): move to profile to avoid misclicks

### DIFF
--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -3,7 +3,6 @@ import { CalendarMonth, CalendarToday, PauseCircleRounded, People } from "@mui/i
 import CloudOffRoundedIcon from "@mui/icons-material/CloudOffRounded";
 import ErrorRoundedIcon from "@mui/icons-material/ErrorRounded";
 import LoginIcon from "@mui/icons-material/Login";
-import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
 import SettingsRoundedIcon from "@mui/icons-material/SettingsRounded";
 import { Badge, Box, Tooltip, useTheme } from "@mui/material";
 import Button from "@mui/material/Button";
@@ -169,11 +168,6 @@ function ConfigBar({
                                 </Box>
                             </Tooltip>
                         )}
-                        <Tooltip title={"Logg ut"}>
-                            <IconButton href={"/api/auth/logout"}>
-                                <LogoutRoundedIcon />
-                            </IconButton>
-                        </Tooltip>
                     </Box>
                 )}
             </>

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -72,6 +72,7 @@ function ConfigBar({
                             display: "flex",
                             alignItems: "center",
                             gap: { xs: 1, md: 1.5 },
+                            marginRight: 1,
                         }}
                     >
                         {isConfigError ? (

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -1,6 +1,8 @@
 import { useUser } from "@auth0/nextjs-auth0/client";
 import { PersonRounded } from "@mui/icons-material";
-import { Box, Typography, useTheme } from "@mui/material";
+import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
+import { Box, Stack, Typography, useTheme } from "@mui/material";
+import Button from "@mui/material/Button";
 import React, { useState } from "react";
 import Dropzone from "react-dropzone";
 
@@ -241,6 +243,11 @@ function Profile({
                                 pointerEvents: "none",
                             }}
                         />
+                        <Stack direction={"row"} justifyContent={"center"}>
+                            <Button color={"error"} startIcon={<LogoutRoundedIcon />} href={"/api/auth/logout"}>
+                                Logg ut
+                            </Button>
+                        </Stack>
                     </Box>
                     <EditAvatarDialog
                         open={editAvatarDialogOpen}

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -243,8 +243,13 @@ function Profile({
                                 pointerEvents: "none",
                             }}
                         />
-                        <Stack direction={"row"} justifyContent={"center"}>
-                            <Button color={"error"} startIcon={<LogoutRoundedIcon />} href={"/api/auth/logout"}>
+                        <Stack alignItems={"center"} mt={2}>
+                            <Button
+                                variant={"outlined"}
+                                color={"error"}
+                                startIcon={<LogoutRoundedIcon />}
+                                href={"/api/auth/logout"}
+                            >
                                 Logg ut
                             </Button>
                         </Stack>


### PR DESCRIPTION
I have already fat-fingered the logout button a lot of times since the profile icon is now clickable and useful. It also makes more sense to have the logout button on the profile page since that reduces the size of the configbar, which is quite chonky on mobile. The use of the logout button is also super rare for normal users, I feel like it is mostly a thing we use during development.
<img width="461" alt="Screenshot 2024-03-14 at 11 31 16" src="https://github.com/mathiazom/rezervo-web/assets/26925695/f869161b-1f73-4f81-8aab-201844a27067">

