### PR TITLE
feat(a11y): improve keyboard navigation

### DIFF
--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -163,9 +163,9 @@ function ConfigBar({
                         {user.name && (
                             <Tooltip title={user.name}>
                                 <Box sx={{ position: "relative" }}>
-                                    <Box onClick={() => onProfileOpen()}>
+                                    <IconButton onClick={() => onProfileOpen()}>
                                         <UserAvatar userId={"me"} username={user.name} />
-                                    </Box>
+                                    </IconButton>
                                 </Box>
                             </Tooltip>
                         )}

--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -1,5 +1,15 @@
 import { CancelRounded, EventBusy, EventRepeat } from "@mui/icons-material";
-import { AvatarGroup, Badge, Box, Card, CardContent, Collapse, Tooltip, Typography } from "@mui/material";
+import {
+    AvatarGroup,
+    Badge,
+    Box,
+    Card,
+    CardActionArea,
+    CardContent,
+    Collapse,
+    Tooltip,
+    Typography,
+} from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import React, { useEffect, useState } from "react";
 
@@ -90,7 +100,9 @@ const ClassCard = ({
                 },
             }}
         >
-            <Box
+            <CardActionArea
+                disableRipple
+                onClick={onInfo}
                 sx={{
                     opacity: isInThePast || _class.isCancelled ? 0.5 : 1,
                     background: "none",
@@ -120,12 +132,9 @@ const ClassCard = ({
                     />
                 )}
                 <CardContent
-                    className={"unselectable"}
-                    onClick={onInfo}
                     sx={{
                         zIndex: 1,
                         position: "relative",
-                        cursor: "pointer",
                         display: "flex",
                         justifyContent: "space-between",
                         "&:last-child": {
@@ -259,7 +268,7 @@ const ClassCard = ({
                         )}
                     </Box>
                 </CardContent>
-            </Box>
+            </CardActionArea>
         </Card>
     );
 };


### PR DESCRIPTION
This PR fixes a few small keyboard navigation issues:
- Make profile navigatable by keyboard
- Make the profile have cursor: pointer indicating that it is clickable
- Employ CardActionArea to make cards keyboard navigatable
- CardActionArea also adds a slight tint to classes you hover over, indicating the primary click action, which is neat 🧑‍🔧 

https://github.com/mathiazom/rezervo-web/assets/26925695/5eb28bf7-55db-471a-8e34-2f44249380be

