### PR TITLE
fix(useUserConfig): ignore 401 errors to avoid error state on signup

### DIFF
--- a/src/lib/hooks/useUserConfig.ts
+++ b/src/lib/hooks/useUserConfig.ts
@@ -48,7 +48,8 @@ export function useUserConfig(chain: ChainIdentifier) {
 
     return {
         userConfig: data,
-        userConfigError: !isLoading && !isMutating && error && error.status !== 404 ? error : null,
+        userConfigError:
+            !isLoading && !isMutating && error && error.status !== 404 && error.status !== 401 ? error : null,
         userConfigLoading: isLoading || isMutating,
         mutateUserConfig: mutate,
         putUserConfig: trigger,


### PR DESCRIPTION
Resolves https://github.com/mathiazom/rezervo-web/issues/126

The 401 will probably not occur normally anyway, as the user always has permission to its config. I think this error state is mostly for catching 500-range errors where there is something terribly wrong at the backend.