### PR TITLE
fix(ClassPopularityMeter): add missing () to avoid null text 🤓🕵️

### DIFF
--- a/src/components/schedule/class/ClassPopularityMeter.tsx
+++ b/src/components/schedule/class/ClassPopularityMeter.tsx
@@ -39,7 +39,8 @@ const ClassPopularityMeter = ({
         return (
             <Tooltip
                 title={
-                    "Påmelding for denne timen har åpnet. " + stringifyClassPopularity(_class, historicPopularity) ?? ""
+                    "Påmelding for denne timen har åpnet. " +
+                    (stringifyClassPopularity(_class, historicPopularity) ?? "")
                 }
             >
                 <RippleBadge


### PR DESCRIPTION
## Before
<img width="701" alt="Screenshot 2024-04-11 at 16 20 21" src="https://github.com/mathiazom/rezervo-web/assets/26925695/adabca24-3317-4a9a-9cc8-98635689ab3b">

## After
<img width="701" alt="Screenshot 2024-04-11 at 16 20 38" src="https://github.com/mathiazom/rezervo-web/assets/26925695/b8250159-23b8-433b-9487-ca64876da989">
