### PR TITLE
SuperDRY Next API Endpoints

### DIFF
--- a/src/app/api/[chain]/all-configs/route.ts
+++ b/src/app/api/[chain]/all-configs/route.ts
@@ -1,20 +1,3 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    get,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    return await doOperation(() => get(`${chainIdentifier}/all-configs`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "all-configs", { withChainIdentifier: true });

--- a/src/app/api/[chain]/book/route.ts
+++ b/src/app/api/[chain]/book/route.ts
@@ -1,21 +1,3 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    chainIdentifierFromContext,
-    doOperation,
-    post,
-    respondNotFound,
-    respondUnauthorized,
-    tryUseRefreshToken,
-} from "@/lib/helpers/api";
-
-export const POST = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    const data = await req.text();
-    return await doOperation(() => post(`${chainIdentifier}/book`, accessToken, data));
-});
+export const POST = createGenericEndpoint("POST", "book", { withChainIdentifier: true });

--- a/src/app/api/[chain]/cancel-booking/route.ts
+++ b/src/app/api/[chain]/cancel-booking/route.ts
@@ -1,21 +1,3 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    post,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
-
-export const POST = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    const data = await req.text();
-    return await doOperation(() => post(`${chainIdentifier}/cancel-booking`, accessToken, data));
-});
+export const POST = createGenericEndpoint("POST", "cancel-booking", { withChainIdentifier: true });

--- a/src/app/api/[chain]/config/route.ts
+++ b/src/app/api/[chain]/config/route.ts
@@ -1,32 +1,5 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    get,
-    put,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
+export const GET = createGenericEndpoint("GET", "config", { withChainIdentifier: true });
 
-export const GET = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    return await doOperation(() => get(`${chainIdentifier}/config`, accessToken));
-});
-
-export const PUT = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    const data = await req.text();
-    return await doOperation(() => put(`${chainIdentifier}/config`, accessToken, data));
-});
+export const PUT = createGenericEndpoint("PUT", "config", { withChainIdentifier: true });

--- a/src/app/api/[chain]/sessions-index/route.ts
+++ b/src/app/api/[chain]/sessions-index/route.ts
@@ -1,20 +1,3 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    get,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    return await doOperation(() => get(`${chainIdentifier}/sessions-index`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "sessions-index", { withChainIdentifier: true });

--- a/src/app/api/[chain]/user/route.ts
+++ b/src/app/api/[chain]/user/route.ts
@@ -1,32 +1,5 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    get,
-    put,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
+export const GET = createGenericEndpoint("GET", "user", { withChainIdentifier: true });
 
-export const GET = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    return await doOperation(() => get(`${chainIdentifier}/user`, accessToken));
-});
-
-export const PUT = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    const data = await req.text();
-    return await doOperation(() => put(`${chainIdentifier}/user`, accessToken, data));
-});
+export const PUT = createGenericEndpoint("PUT", "user", { withChainIdentifier: true });

--- a/src/app/api/[chain]/user/totp/route.ts
+++ b/src/app/api/[chain]/user/totp/route.ts
@@ -1,21 +1,3 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    put,
-    tryUseRefreshToken,
-    respondUnauthorized,
-    respondNotFound,
-    doOperation,
-    chainIdentifierFromContext,
-} from "@/lib/helpers/api";
-
-export const PUT = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const chainIdentifier = chainIdentifierFromContext(ctx as AppRouteHandlerFnContext);
-    if (chainIdentifier === null) return respondNotFound();
-
-    const data = await req.text();
-    return await doOperation(() => put(`${chainIdentifier}/user/totp`, accessToken, data));
-});
+export const PUT = createGenericEndpoint("PUT", "user/totp", { withChainIdentifier: true });

--- a/src/app/api/cal-url/route.ts
+++ b/src/app/api/cal-url/route.ts
@@ -1,10 +1,6 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createAuthenticatedEndpoint, doOperation, get } from "@/lib/helpers/api";
 
-import { doOperation, get, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
+export const GET = createAuthenticatedEndpoint(async (req, _ctx, accessToken) => {
     const response = await doOperation(() => get(`cal-token`, accessToken));
     if (!response.ok) return response;
 

--- a/src/app/api/cal-url/route.ts
+++ b/src/app/api/cal-url/route.ts
@@ -2,7 +2,7 @@ import { createAuthenticatedEndpoint, doOperation } from "@/lib/helpers/api";
 import { get } from "@/lib/helpers/requests";
 
 export const GET = createAuthenticatedEndpoint(async (req, _ctx, accessToken) => {
-    const response = await doOperation(() => get(`cal-token`, accessToken));
+    const response = await doOperation(() => get(`cal-token`, { accessToken }));
     if (!response.ok) return response;
 
     const calendarToken = await response.json();

--- a/src/app/api/cal-url/route.ts
+++ b/src/app/api/cal-url/route.ts
@@ -1,4 +1,5 @@
-import { createAuthenticatedEndpoint, doOperation, get } from "@/lib/helpers/api";
+import { createAuthenticatedEndpoint, doOperation } from "@/lib/helpers/api";
+import { get } from "@/lib/helpers/requests";
 
 export const GET = createAuthenticatedEndpoint(async (req, _ctx, accessToken) => {
     const response = await doOperation(() => get(`cal-token`, accessToken));

--- a/src/app/api/community/relationship/route.ts
+++ b/src/app/api/community/relationship/route.ts
@@ -1,11 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, put, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const PUT = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const data = await req.text();
-    return await doOperation(() => put(`community/relationship`, accessToken, data));
-});
+export const PUT = createGenericEndpoint("PUT", "community/relationship");

--- a/src/app/api/community/route.ts
+++ b/src/app/api/community/route.ts
@@ -1,10 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, get, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => get(`community`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "community");

--- a/src/app/api/features/route.ts
+++ b/src/app/api/features/route.ts
@@ -1,10 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, get, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => get(`features`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "features");

--- a/src/app/api/notifications/push/public-key/route.ts
+++ b/src/app/api/notifications/push/public-key/route.ts
@@ -1,10 +1,5 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createAuthenticatedEndpoint } from "@/lib/helpers/api";
 
-import { respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
+export const GET = createAuthenticatedEndpoint(async () => {
     return Response.json(process.env["WEB_PUSH_PUBLIC_KEY"]);
 });

--- a/src/app/api/notifications/push/route.ts
+++ b/src/app/api/notifications/push/route.ts
@@ -1,19 +1,5 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { destroy, doOperation, put, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
+export const PUT = createGenericEndpoint("PUT", "notifications/push");
 
-export const PUT = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const data = await req.text();
-    return await doOperation(() => put(`notifications/push`, accessToken, data));
-});
-
-export const DELETE = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const data = await req.text();
-    return await doOperation(() => destroy(`notifications/push`, accessToken, data));
-});
+export const DELETE = createGenericEndpoint("DELETE", "notifications/push");

--- a/src/app/api/notifications/push/verify/route.ts
+++ b/src/app/api/notifications/push/verify/route.ts
@@ -1,11 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, post, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const POST = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const data = await req.text();
-    return await doOperation(() => post(`notifications/push/verify`, accessToken, data));
-});
+export const POST = createGenericEndpoint("POST", "notifications/push/verify");

--- a/src/app/api/preferences/route.ts
+++ b/src/app/api/preferences/route.ts
@@ -1,17 +1,5 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, get, put, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
+export const GET = createGenericEndpoint("GET", "preferences");
 
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => get(`preferences`, accessToken));
-});
-
-export const PUT = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-    const data = await req.text();
-    return await doOperation(() => put(`preferences`, accessToken, data));
-});
+export const PUT = createGenericEndpoint("PUT", "preferences");

--- a/src/app/api/user/[userId]/avatar/[size]/route.ts
+++ b/src/app/api/user/[userId]/avatar/[size]/route.ts
@@ -1,11 +1,11 @@
 import {
     createAuthenticatedEndpoint,
     doOperation,
-    get,
     respondNotFound,
     thumbnailSizeFromContext,
     userIdFromContext,
 } from "@/lib/helpers/api";
+import { get } from "@/lib/helpers/requests";
 
 export const GET = createAuthenticatedEndpoint(async (req, ctx, accessToken) => {
     const userId = userIdFromContext(ctx);

--- a/src/app/api/user/[userId]/avatar/[size]/route.ts
+++ b/src/app/api/user/[userId]/avatar/[size]/route.ts
@@ -1,33 +1,21 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
-
 import {
-    buildBackendPath,
+    createAuthenticatedEndpoint,
     doOperation,
+    get,
     respondNotFound,
-    respondUnauthorized,
     thumbnailSizeFromContext,
-    tryUseRefreshToken,
     userIdFromContext,
 } from "@/lib/helpers/api";
 
-export const GET = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    const userId = userIdFromContext(ctx as AppRouteHandlerFnContext);
+export const GET = createAuthenticatedEndpoint(async (req, ctx, accessToken) => {
+    const userId = userIdFromContext(ctx);
     if (userId === null) return respondNotFound();
 
-    const thumbnailSize = thumbnailSizeFromContext(ctx as AppRouteHandlerFnContext);
+    const thumbnailSize = thumbnailSizeFromContext(ctx);
     if (thumbnailSize === null) return respondNotFound();
 
     // TODO: cleaner implementation
     req.nextUrl.searchParams.get("CACHE-BUSTER-NOT-ACTUALLY-USED");
 
-    return await doOperation(() =>
-        fetch(buildBackendPath(`user/${userId}/avatar/${thumbnailSize}`), {
-            headers: {
-                Authorization: `Bearer ${accessToken}`,
-            },
-        }),
-    );
+    return await doOperation(() => get(`user/${userId}/avatar/${thumbnailSize}`, accessToken));
 });

--- a/src/app/api/user/[userId]/avatar/[size]/route.ts
+++ b/src/app/api/user/[userId]/avatar/[size]/route.ts
@@ -17,5 +17,5 @@ export const GET = createAuthenticatedEndpoint(async (req, ctx, accessToken) => 
     // TODO: cleaner implementation
     req.nextUrl.searchParams.get("CACHE-BUSTER-NOT-ACTUALLY-USED");
 
-    return await doOperation(() => get(`user/${userId}/avatar/${thumbnailSize}`, accessToken));
+    return await doOperation(() => get(`user/${userId}/avatar/${thumbnailSize}`, { accessToken }));
 });

--- a/src/app/api/user/[userId]/avatar/route.ts
+++ b/src/app/api/user/[userId]/avatar/route.ts
@@ -1,38 +1,5 @@
-import { AppRouteHandlerFnContext, withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import {
-    buildBackendPath,
-    destroy,
-    doOperation,
-    isUserMeFromContext,
-    respondNotFound,
-    respondUnauthorized,
-    tryUseRefreshToken,
-} from "@/lib/helpers/api";
+export const PUT = createGenericEndpoint("PUT", "user/me/avatar", { checkUserIsMe: true, useFormData: true });
 
-export const PUT = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    if (!isUserMeFromContext(ctx as AppRouteHandlerFnContext)) return respondNotFound();
-
-    const formData = await req.formData();
-    return await doOperation(() =>
-        fetch(buildBackendPath("user/me/avatar"), {
-            method: "PUT",
-            headers: {
-                Authorization: `Bearer ${accessToken}`,
-            },
-            body: formData,
-        }),
-    );
-});
-
-export const DELETE = withApiAuthRequired(async (req, ctx) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    if (!isUserMeFromContext(ctx as AppRouteHandlerFnContext)) return respondNotFound();
-
-    return await doOperation(() => destroy("user/me/avatar", accessToken));
-});
+export const DELETE = createGenericEndpoint("DELETE", "user/me/avatar", { checkUserIsMe: true });

--- a/src/app/api/user/[userId]/avatar/route.ts
+++ b/src/app/api/user/[userId]/avatar/route.ts
@@ -1,5 +1,5 @@
 import { createGenericEndpoint } from "@/lib/helpers/api";
 
-export const PUT = createGenericEndpoint("PUT", "user/me/avatar", { checkUserIsMe: true, useFormData: true });
+export const PUT = createGenericEndpoint("PUT", "user/me/avatar", { onlyMe: true, useFormData: true });
 
-export const DELETE = createGenericEndpoint("DELETE", "user/me/avatar", { checkUserIsMe: true });
+export const DELETE = createGenericEndpoint("DELETE", "user/me/avatar", { onlyMe: true });

--- a/src/app/api/user/chain-configs/route.ts
+++ b/src/app/api/user/chain-configs/route.ts
@@ -1,10 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, get, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => get(`user/chain-configs`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "user/chain-configs");

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,10 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, put, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const PUT = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => put(`user`, accessToken));
-});
+export const PUT = createGenericEndpoint("PUT", "user");

--- a/src/app/api/user/sessions/route.ts
+++ b/src/app/api/user/sessions/route.ts
@@ -1,10 +1,3 @@
-import { withApiAuthRequired } from "@auth0/nextjs-auth0";
+import { createGenericEndpoint } from "@/lib/helpers/api";
 
-import { doOperation, get, respondUnauthorized, tryUseRefreshToken } from "@/lib/helpers/api";
-
-export const GET = withApiAuthRequired(async (req) => {
-    const accessToken = await tryUseRefreshToken(req);
-    if (!accessToken) return respondUnauthorized();
-
-    return await doOperation(() => get(`user/sessions`, accessToken));
-});
+export const GET = createGenericEndpoint("GET", "user/sessions");

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -14,7 +14,6 @@ import WeekSchedule from "@/components/schedule/WeekSchedule";
 import AppBar from "@/components/utils/AppBar";
 import ChainSwitcher from "@/components/utils/ChainSwitcher";
 import ErrorMessage from "@/components/utils/ErrorMessage";
-import PageHead from "@/components/utils/PageHead";
 import { CLASS_ID_QUERY_PARAM, ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
 import {
     compactISOWeekString,
@@ -242,7 +241,6 @@ function Chain({
 
     return (
         <>
-            <PageHead title={`${chain.profile.identifier}-rezervo`} />
             <Stack sx={{ height: "100%", overflow: "hidden" }}>
                 <Box sx={{ flexShrink: 0 }}>
                     <AppBar

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -55,7 +55,7 @@ function ConfigBar({
 
     useEffect(() => {
         if (user == undefined) return;
-        put("user", { useAuthProxy: true }).then(async (res) => {
+        put("user", { mode: "authProxy" }).then(async (res) => {
             if (!res.ok) return;
             setMyUserId(await res.json());
             await onRefetchConfig();

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -10,7 +10,7 @@ import IconButton from "@mui/material/IconButton";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { UserAvatar } from "@/components/utils/UserAvatar";
-import { buildBackendAuthProxyPath, put } from "@/lib/helpers/requests";
+import { buildAuthProxyPath, put } from "@/lib/helpers/requests";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { useMyUserId } from "@/stores/userStore";
 import { ChainIdentifier } from "@/types/chain";
@@ -55,7 +55,7 @@ function ConfigBar({
 
     useEffect(() => {
         if (user == undefined) return;
-        put("user").then(async (res) => {
+        put("user", { useAuthProxy: true }).then(async (res) => {
             if (!res.ok) return;
             setMyUserId(await res.json());
             await onRefetchConfig();
@@ -67,7 +67,7 @@ function ConfigBar({
         !isLoadingUser && (
             <>
                 {user == undefined ? (
-                    <Button endIcon={<LoginIcon />} href={buildBackendAuthProxyPath("auth/login")}>
+                    <Button endIcon={<LoginIcon />} href={buildAuthProxyPath("auth/login")}>
                         Logg inn
                     </Button>
                 ) : (

--- a/src/components/configuration/ConfigBar.tsx
+++ b/src/components/configuration/ConfigBar.tsx
@@ -10,6 +10,7 @@ import IconButton from "@mui/material/IconButton";
 import React, { useEffect, useMemo, useState } from "react";
 
 import { UserAvatar } from "@/components/utils/UserAvatar";
+import { buildBackendAuthProxyPath, put } from "@/lib/helpers/requests";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { useMyUserId } from "@/stores/userStore";
 import { ChainIdentifier } from "@/types/chain";
@@ -54,9 +55,7 @@ function ConfigBar({
 
     useEffect(() => {
         if (user == undefined) return;
-        fetch("/api/user", {
-            method: "PUT",
-        }).then(async (res) => {
+        put("user").then(async (res) => {
             if (!res.ok) return;
             setMyUserId(await res.json());
             await onRefetchConfig();
@@ -68,7 +67,7 @@ function ConfigBar({
         !isLoadingUser && (
             <>
                 {user == undefined ? (
-                    <Button endIcon={<LoginIcon />} href={"/api/auth/login"}>
+                    <Button endIcon={<LoginIcon />} href={buildBackendAuthProxyPath("auth/login")}>
                         Logg inn
                     </Button>
                 ) : (

--- a/src/components/modals/BookingPopupModal.tsx
+++ b/src/components/modals/BookingPopupModal.tsx
@@ -32,7 +32,10 @@ const BookingPopupModal = ({
 
     async function book() {
         setBookingLoading(true);
-        await post(`${chain}/book`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
+        await post(`${chain}/book`, {
+            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
+            useAuthProxy: true,
+        });
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);
@@ -41,7 +44,10 @@ const BookingPopupModal = ({
 
     async function cancelBooking() {
         setBookingLoading(true);
-        await post(`${chain}/cancel-booking`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
+        await post(`${chain}/cancel-booking`, {
+            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
+            useAuthProxy: true,
+        });
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/BookingPopupModal.tsx
+++ b/src/components/modals/BookingPopupModal.tsx
@@ -5,8 +5,8 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import React, { useState } from "react";
 
-import { postBookingRequest } from "@/lib/helpers/fetchers";
 import { hasWaitingList } from "@/lib/helpers/popularity";
+import { post } from "@/lib/helpers/requests";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { useUserSessionsIndex } from "@/lib/hooks/useUserSessionsIndex";
 import { BookingPopupAction, ChainIdentifier, RezervoClass } from "@/types/chain";
@@ -32,7 +32,7 @@ const BookingPopupModal = ({
 
     async function book() {
         setBookingLoading(true);
-        await postBookingRequest(chain, _class.id.toString(), "book");
+        await post(`${chain}/book`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);
@@ -41,7 +41,7 @@ const BookingPopupModal = ({
 
     async function cancelBooking() {
         setBookingLoading(true);
-        await postBookingRequest(chain, _class.id.toString(), "cancel-booking");
+        await post(`${chain}/cancel-booking`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/BookingPopupModal.tsx
+++ b/src/components/modals/BookingPopupModal.tsx
@@ -5,6 +5,7 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import React, { useState } from "react";
 
+import { postBookingRequest } from "@/lib/helpers/fetchers";
 import { hasWaitingList } from "@/lib/helpers/popularity";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { useUserSessionsIndex } from "@/lib/hooks/useUserSessionsIndex";
@@ -31,10 +32,7 @@ const BookingPopupModal = ({
 
     async function book() {
         setBookingLoading(true);
-        await fetch(`/api/${chain}/book`, {
-            method: "POST",
-            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-        });
+        await postBookingRequest(chain, _class.id.toString(), "book");
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);
@@ -43,10 +41,7 @@ const BookingPopupModal = ({
 
     async function cancelBooking() {
         setBookingLoading(true);
-        await fetch(`/api/${chain}/cancel-booking`, {
-            method: "POST",
-            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-        });
+        await postBookingRequest(chain, _class.id.toString(), "cancel-booking");
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/BookingPopupModal.tsx
+++ b/src/components/modals/BookingPopupModal.tsx
@@ -34,7 +34,7 @@ const BookingPopupModal = ({
         setBookingLoading(true);
         await post(`${chain}/book`, {
             body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-            useAuthProxy: true,
+            mode: "authProxy",
         });
         await mutateSessionsIndex();
         await mutateUserSessions();
@@ -46,7 +46,7 @@ const BookingPopupModal = ({
         setBookingLoading(true);
         await post(`${chain}/cancel-booking`, {
             body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-            useAuthProxy: true,
+            mode: "authProxy",
         });
         await mutateSessionsIndex();
         await mutateUserSessions();

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -28,6 +28,7 @@ import ConfirmCancellation from "@/components/schedule/class/ConfirmCancellation
 import { NoShowBadgeIcon } from "@/components/utils/NoShowBadgeIcon";
 import { PlannedNotBookedBadgeIcon } from "@/components/utils/PlannedNotBookedBadgeIcon";
 import { isClassInThePast } from "@/lib/helpers/date";
+import { postBookingRequest } from "@/lib/helpers/fetchers";
 import { hasWaitingList, stringifyClassPopularity } from "@/lib/helpers/popularity";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
 import { useUserConfig } from "@/lib/hooks/useUserConfig";
@@ -82,10 +83,7 @@ export default function ClassInfo({
 
     async function book() {
         setBookingLoading(true);
-        await fetch(`/api/${chain}/book`, {
-            method: "POST",
-            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-        });
+        await postBookingRequest(chain, _class.id.toString(), "book");
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -85,7 +85,7 @@ export default function ClassInfo({
         setBookingLoading(true);
         await post(`${chain}/book`, {
             body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-            useAuthProxy: true,
+            mode: "authProxy",
         });
         await mutateSessionsIndex();
         await mutateUserSessions();

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -83,7 +83,10 @@ export default function ClassInfo({
 
     async function book() {
         setBookingLoading(true);
-        await post(`${chain}/book`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
+        await post(`${chain}/book`, {
+            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
+            useAuthProxy: true,
+        });
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -28,9 +28,9 @@ import ConfirmCancellation from "@/components/schedule/class/ConfirmCancellation
 import { NoShowBadgeIcon } from "@/components/utils/NoShowBadgeIcon";
 import { PlannedNotBookedBadgeIcon } from "@/components/utils/PlannedNotBookedBadgeIcon";
 import { isClassInThePast } from "@/lib/helpers/date";
-import { postBookingRequest } from "@/lib/helpers/fetchers";
 import { hasWaitingList, stringifyClassPopularity } from "@/lib/helpers/popularity";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
+import { post } from "@/lib/helpers/requests";
 import { useUserConfig } from "@/lib/hooks/useUserConfig";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { useUserSessionsIndex } from "@/lib/hooks/useUserSessionsIndex";
@@ -83,7 +83,7 @@ export default function ClassInfo({
 
     async function book() {
         setBookingLoading(true);
-        await postBookingRequest(chain, _class.id.toString(), "book");
+        await post(`${chain}/book`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
         await mutateSessionsIndex();
         await mutateUserSessions();
         setBookingLoading(false);

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -11,6 +11,7 @@ import EditAvatarDialog from "@/components/modals/Profile/EditAvatarDialog";
 import ProfileAvatar from "@/components/modals/Profile/ProfileAvatar";
 import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
 import { ALLOWED_AVATAR_FILE_TYPES } from "@/lib/consts";
+import { buildBackendAuthProxyPath, destroy, put } from "@/lib/helpers/requests";
 import { usePositionFromBounds } from "@/lib/hooks/usePositionFromBounds";
 import { useMyAvatar } from "@/stores/userStore";
 import { Position } from "@/types/math";
@@ -79,10 +80,7 @@ function Profile({
         setAvatarPreviewDataURL(URL.createObjectURL(file));
         const formData = new FormData();
         formData.append("file", file);
-        const res = await fetch("/api/user/me/avatar", {
-            method: "PUT",
-            body: formData,
-        });
+        const res = await put("user/me/avatar", formData, null);
         if (res.ok) {
             updateMyAvatarLastModified();
         } else if (res.status === 413) {
@@ -96,9 +94,7 @@ function Profile({
     }
 
     function deleteAvatar() {
-        fetch("/api/user/me/avatar", {
-            method: "DELETE",
-        })
+        destroy("user/me/avatar")
             .then((res) => {
                 console.log(res);
                 if (!res.ok) {
@@ -248,7 +244,7 @@ function Profile({
                                 variant={"outlined"}
                                 color={"error"}
                                 startIcon={<LogoutRoundedIcon />}
-                                href={"/api/auth/logout"}
+                                href={buildBackendAuthProxyPath("auth/logout")}
                             >
                                 Logg ut
                             </Button>

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -11,7 +11,7 @@ import EditAvatarDialog from "@/components/modals/Profile/EditAvatarDialog";
 import ProfileAvatar from "@/components/modals/Profile/ProfileAvatar";
 import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
 import { ALLOWED_AVATAR_FILE_TYPES } from "@/lib/consts";
-import { buildBackendAuthProxyPath, destroy, put } from "@/lib/helpers/requests";
+import { buildAuthProxyPath, destroy, put } from "@/lib/helpers/requests";
 import { usePositionFromBounds } from "@/lib/hooks/usePositionFromBounds";
 import { useMyAvatar } from "@/stores/userStore";
 import { Position } from "@/types/math";
@@ -80,7 +80,11 @@ function Profile({
         setAvatarPreviewDataURL(URL.createObjectURL(file));
         const formData = new FormData();
         formData.append("file", file);
-        const res = await put("user/me/avatar", formData, null);
+        const res = await put("user/me/avatar", {
+            body: formData,
+            withContentType: "NO_CONTENT_TYPE",
+            useAuthProxy: true,
+        });
         if (res.ok) {
             updateMyAvatarLastModified();
         } else if (res.status === 413) {
@@ -94,9 +98,8 @@ function Profile({
     }
 
     function deleteAvatar() {
-        destroy("user/me/avatar")
+        destroy("user/me/avatar", { useAuthProxy: true })
             .then((res) => {
-                console.log(res);
                 if (!res.ok) {
                     onAvatarMutateError(AvatarMutateError.UNKNOWN);
                     return;
@@ -244,7 +247,7 @@ function Profile({
                                 variant={"outlined"}
                                 color={"error"}
                                 startIcon={<LogoutRoundedIcon />}
-                                href={buildBackendAuthProxyPath("auth/logout")}
+                                href={buildAuthProxyPath("auth/logout")}
                             >
                                 Logg ut
                             </Button>

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -83,7 +83,7 @@ function Profile({
         const res = await put("user/me/avatar", {
             body: formData,
             withContentType: "NO_CONTENT_TYPE",
-            useAuthProxy: true,
+            mode: "authProxy",
         });
         if (res.ok) {
             updateMyAvatarLastModified();
@@ -98,7 +98,7 @@ function Profile({
     }
 
     function deleteAvatar() {
-        destroy("user/me/avatar", { useAuthProxy: true })
+        destroy("user/me/avatar", { mode: "authProxy" })
             .then((res) => {
                 if (!res.ok) {
                     onAvatarMutateError(AvatarMutateError.UNKNOWN);

--- a/src/components/schedule/class/ConfirmCancellation.tsx
+++ b/src/components/schedule/class/ConfirmCancellation.tsx
@@ -25,7 +25,10 @@ function ConfirmCancellation({
     async function cancelBooking() {
         setOpen(false);
         setLoading(true);
-        await post(`${chain}/cancel-booking`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
+        await post(`${chain}/cancel-booking`, {
+            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
+            useAuthProxy: true,
+        });
         await mutateSessionsIndex();
         await mutateUserSessions();
         setLoading(false);

--- a/src/components/schedule/class/ConfirmCancellation.tsx
+++ b/src/components/schedule/class/ConfirmCancellation.tsx
@@ -2,6 +2,7 @@ import { Typography } from "@mui/material";
 import React, { Dispatch, SetStateAction } from "react";
 
 import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
+import { postBookingRequest } from "@/lib/helpers/fetchers";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { useUserSessionsIndex } from "@/lib/hooks/useUserSessionsIndex";
 import { ChainIdentifier, RezervoClass } from "@/types/chain";
@@ -24,10 +25,7 @@ function ConfirmCancellation({
     async function cancelBooking() {
         setOpen(false);
         setLoading(true);
-        await fetch(`/api/${chain}/cancel-booking`, {
-            method: "POST",
-            body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-        });
+        await postBookingRequest(chain, _class.id.toString(), "cancel-booking");
         await mutateSessionsIndex();
         await mutateUserSessions();
         setLoading(false);

--- a/src/components/schedule/class/ConfirmCancellation.tsx
+++ b/src/components/schedule/class/ConfirmCancellation.tsx
@@ -2,7 +2,7 @@ import { Typography } from "@mui/material";
 import React, { Dispatch, SetStateAction } from "react";
 
 import ConfirmationDialog from "@/components/utils/ConfirmationDialog";
-import { postBookingRequest } from "@/lib/helpers/fetchers";
+import { post } from "@/lib/helpers/requests";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
 import { useUserSessionsIndex } from "@/lib/hooks/useUserSessionsIndex";
 import { ChainIdentifier, RezervoClass } from "@/types/chain";
@@ -25,7 +25,7 @@ function ConfirmCancellation({
     async function cancelBooking() {
         setOpen(false);
         setLoading(true);
-        await postBookingRequest(chain, _class.id.toString(), "cancel-booking");
+        await post(`${chain}/cancel-booking`, JSON.stringify({ classId: _class.id.toString() }, null, 2));
         await mutateSessionsIndex();
         await mutateUserSessions();
         setLoading(false);

--- a/src/components/schedule/class/ConfirmCancellation.tsx
+++ b/src/components/schedule/class/ConfirmCancellation.tsx
@@ -27,7 +27,7 @@ function ConfirmCancellation({
         setLoading(true);
         await post(`${chain}/cancel-booking`, {
             body: JSON.stringify({ classId: _class.id.toString() }, null, 2),
-            useAuthProxy: true,
+            mode: "authProxy",
         });
         await mutateSessionsIndex();
         await mutateUserSessions();

--- a/src/components/utils/UserAvatar.tsx
+++ b/src/components/utils/UserAvatar.tsx
@@ -2,7 +2,7 @@ import { Avatar, Box } from "@mui/material";
 import Image from "next/image";
 import React, { useState } from "react";
 
-import { buildBackendAuthProxyPath } from "@/lib/helpers/requests";
+import { buildAuthProxyPath } from "@/lib/helpers/requests";
 import { avatarColor } from "@/lib/utils/colorUtils";
 import { useMyAvatar, useMyUserId } from "@/stores/userStore";
 
@@ -43,7 +43,7 @@ export function UserAvatar({
             <Image
                 src={
                     previewOverride ??
-                    buildBackendAuthProxyPath(
+                    buildAuthProxyPath(
                         `user/${userId}/avatar/${imgSrcSize}` +
                             ((userId === myUserId || userId === "me") && myAvatarLastModifiedTimestamp
                                 ? `?cache-bust=${myAvatarLastModifiedTimestamp}`

--- a/src/components/utils/UserAvatar.tsx
+++ b/src/components/utils/UserAvatar.tsx
@@ -2,6 +2,7 @@ import { Avatar, Box } from "@mui/material";
 import Image from "next/image";
 import React, { useState } from "react";
 
+import { buildBackendAuthProxyPath } from "@/lib/helpers/requests";
 import { avatarColor } from "@/lib/utils/colorUtils";
 import { useMyAvatar, useMyUserId } from "@/stores/userStore";
 
@@ -42,10 +43,12 @@ export function UserAvatar({
             <Image
                 src={
                     previewOverride ??
-                    `/api/user/${userId}/avatar/${imgSrcSize}` +
-                        ((userId === myUserId || userId === "me") && myAvatarLastModifiedTimestamp
-                            ? `?cache-bust=${myAvatarLastModifiedTimestamp}`
-                            : "")
+                    buildBackendAuthProxyPath(
+                        `user/${userId}/avatar/${imgSrcSize}` +
+                            ((userId === myUserId || userId === "me") && myAvatarLastModifiedTimestamp
+                                ? `?cache-bust=${myAvatarLastModifiedTimestamp}`
+                                : ""),
+                    )
                 }
                 alt={username}
                 width={size}

--- a/src/lib/helpers/api.ts
+++ b/src/lib/helpers/api.ts
@@ -1,4 +1,4 @@
-import { AppRouteHandlerFnContext, getAccessToken } from "@auth0/nextjs-auth0";
+import { AppRouteHandlerFn, AppRouteHandlerFnContext, getAccessToken, withApiAuthRequired } from "@auth0/nextjs-auth0";
 import { HTTP_METHOD } from "next/dist/server/web/http";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -23,31 +23,12 @@ export function chainIdentifierFromContext(context: AppRouteHandlerFnContext): C
     return (typeof chainArg !== "string" ? chainArg?.pop() : chainArg) as ChainIdentifier;
 }
 
-export async function tryUseRefreshToken(req: NextRequest): Promise<string | undefined> {
-    // If your access token is expired, and you have a refresh token
-    // `getAccessToken` will fetch you a new one using the `refresh_token` grant
-    const { accessToken } = await getAccessToken(req, new NextResponse());
-    return accessToken;
-}
-
-export function buildBackendPath(path: string): string {
-    const host = process.env["INTERNAL_CONFIG_HOST"] ?? process.env["NEXT_PUBLIC_CONFIG_HOST"];
-    return `${host}/${path}`;
-}
-
-export function respondUnauthorized(): Response {
-    return Response.json("Not authenticated", { status: 403 });
-}
-
 export function respondInternalServerError(): Response {
     return Response.json("Request failed", { status: 500 });
 }
+
 export function respondNotFound(): Response {
     return Response.json("Not found", { status: 404 });
-}
-
-export function respondNonOkResponse(response: Response): Response {
-    return Response.json(response.statusText, { status: response.status });
 }
 
 export async function doOperation(operation: () => Promise<Response>): Promise<Response> {
@@ -58,36 +39,43 @@ export async function doOperation(operation: () => Promise<Response>): Promise<R
     }
     if (!response.ok) {
         console.error(response);
-        return respondNonOkResponse(response);
+        return Response.json(response.statusText, { status: response.status });
     }
 
     return response;
 }
 
-export function get(path: string, accessToken: string): Promise<Response> {
-    return fetch(buildBackendPath(path), {
-        method: "GET",
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-        cache: "no-store",
-    });
-}
-
-function createRequestInit(method: HTTP_METHOD, accessToken: string, body?: BodyInit): RequestInit {
+function createRequestInit(
+    method: HTTP_METHOD,
+    accessToken?: string,
+    body?: BodyInit,
+    cache?: RequestCache,
+): RequestInit {
+    const headers = new Headers();
     const requestInit: RequestInit = {
         method,
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
+        headers,
     };
-
+    if (accessToken) {
+        headers.append("Authorization", `Bearer ${accessToken}`);
+    }
     if (body) {
         requestInit.body = body;
-        // @ts-expect-error - TS doesn't know about this header
-        requestInit.headers["Content-Type"] = "application/json";
+        headers.append("Content-Type", "application/json");
+    }
+    if (cache) {
+        requestInit.cache = cache;
     }
     return requestInit;
+}
+
+function buildBackendPath(path: string): string {
+    const host = process.env["INTERNAL_CONFIG_HOST"] ?? process.env["NEXT_PUBLIC_CONFIG_HOST"];
+    return `${host}/${path}`;
+}
+
+export function get(path: string, accessToken?: string): Promise<Response> {
+    return fetch(buildBackendPath(path), createRequestInit("GET", accessToken, undefined, "no-store"));
 }
 
 export function put(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
@@ -99,4 +87,59 @@ export function post(path: string, accessToken: string, body?: BodyInit): Promis
 }
 export function destroy(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
     return fetch(buildBackendPath(path), createRequestInit("DELETE", accessToken, body));
+}
+
+export function createAuthenticatedEndpoint(
+    handler: (req: NextRequest, ctx: AppRouteHandlerFnContext, accessToken: string) => Promise<Response>,
+): AppRouteHandlerFn {
+    return withApiAuthRequired(async (req, ctx) => {
+        // If your access token is expired, and you have a refresh token
+        // `getAccessToken` will fetch you a new one using the `refresh_token` grant
+        const { accessToken } = await getAccessToken(req, new NextResponse());
+
+        if (!accessToken) return Response.json("Not authenticated", { status: 403 });
+        return handler(req, ctx as AppRouteHandlerFnContext, accessToken);
+    });
+}
+
+export function createGenericEndpoint(
+    method: HTTP_METHOD,
+    targetPath: string,
+    options?: { withChainIdentifier?: boolean; checkUserIsMe?: boolean; useFormData?: boolean },
+): AppRouteHandlerFn {
+    return createAuthenticatedEndpoint(async (req, ctx, accessToken) => {
+        let pathPrefix = "";
+        if (options?.withChainIdentifier) {
+            const chainIdentifier = chainIdentifierFromContext(ctx);
+            if (chainIdentifier === null) return respondNotFound();
+            pathPrefix += `${chainIdentifier}/`;
+        }
+
+        if (options?.checkUserIsMe && !isUserMeFromContext(ctx)) {
+            return respondNotFound();
+        }
+
+        let body: BodyInit | undefined;
+        if (["POST", "PUT", "DELETE"].includes(method)) {
+            if (options?.useFormData) {
+                body = await req.formData();
+            } else {
+                body = await req.text();
+            }
+        }
+
+        switch (method) {
+            case "GET":
+                return await doOperation(() => get(pathPrefix + targetPath, accessToken));
+            case "POST":
+                return await doOperation(() => post(pathPrefix + targetPath, accessToken, body));
+            case "PUT":
+                return await doOperation(() => put(pathPrefix + targetPath, accessToken, body));
+            case "DELETE":
+                return await doOperation(() => destroy(pathPrefix + targetPath, accessToken, body));
+
+            default:
+                throw new Error("HTTP method not implemented");
+        }
+    });
 }

--- a/src/lib/helpers/api.ts
+++ b/src/lib/helpers/api.ts
@@ -1,4 +1,5 @@
 import { AppRouteHandlerFnContext, getAccessToken } from "@auth0/nextjs-auth0";
+import { HTTP_METHOD } from "next/dist/server/web/http";
 import { NextRequest, NextResponse } from "next/server";
 
 import { ChainIdentifier } from "@/types/chain";
@@ -73,46 +74,29 @@ export function get(path: string, accessToken: string): Promise<Response> {
     });
 }
 
-export function put(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
+function createRequestInit(method: HTTP_METHOD, accessToken: string, body?: BodyInit): RequestInit {
     const requestInit: RequestInit = {
-        method: "PUT",
+        method,
         headers: {
             Authorization: `Bearer ${accessToken}`,
         },
     };
+
     if (body) {
         requestInit.body = body;
         // @ts-expect-error - TS doesn't know about this header
         requestInit.headers["Content-Type"] = "application/json";
     }
-    return fetch(buildBackendPath(path), requestInit);
+    return requestInit;
+}
+
+export function put(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
+    return fetch(buildBackendPath(path), createRequestInit("PUT", accessToken, body));
 }
 
 export function post(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
-    const requestInit: RequestInit = {
-        method: "POST",
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-    };
-    if (body) {
-        requestInit.body = body;
-        // @ts-expect-error - TS doesn't know about this header
-        requestInit.headers["Content-Type"] = "application/json";
-    }
-    return fetch(buildBackendPath(path), requestInit);
+    return fetch(buildBackendPath(path), createRequestInit("POST", accessToken, body));
 }
 export function destroy(path: string, accessToken: string, body?: BodyInit): Promise<Response> {
-    const requestInit: RequestInit = {
-        method: "DELETE",
-        headers: {
-            Authorization: `Bearer ${accessToken}`,
-        },
-    };
-    if (body) {
-        requestInit.body = body;
-        // @ts-expect-error - TS doesn't know about this header
-        requestInit.headers["Content-Type"] = "application/json";
-    }
-    return fetch(buildBackendPath(path), requestInit);
+    return fetch(buildBackendPath(path), createRequestInit("DELETE", accessToken, body));
 }

--- a/src/lib/helpers/api.ts
+++ b/src/lib/helpers/api.ts
@@ -63,17 +63,17 @@ export function createAuthenticatedEndpoint(
 export function createGenericEndpoint(
     method: HTTP_METHOD,
     targetPath: string,
-    options?: { withChainIdentifier?: boolean; checkUserIsMe?: boolean; useFormData?: boolean },
+    options?: { withChainIdentifier?: boolean; onlyMe?: boolean; useFormData?: boolean },
 ): AppRouteHandlerFn {
     return createAuthenticatedEndpoint(async (req, ctx, accessToken) => {
-        let pathPrefix = "";
+        let path = targetPath;
         if (options?.withChainIdentifier) {
             const chainIdentifier = chainIdentifierFromContext(ctx);
             if (chainIdentifier === null) return respondNotFound();
-            pathPrefix += `${chainIdentifier}/`;
+            path = `${chainIdentifier}/` + path;
         }
 
-        if (options?.checkUserIsMe && !isUserMeFromContext(ctx)) {
+        if (options?.onlyMe && !isUserMeFromContext(ctx)) {
             return respondNotFound();
         }
 
@@ -89,13 +89,13 @@ export function createGenericEndpoint(
 
         switch (method) {
             case "GET":
-                return await doOperation(() => get(pathPrefix + targetPath, requestOptions));
+                return await doOperation(() => get(path, requestOptions));
             case "POST":
-                return await doOperation(() => post(pathPrefix + targetPath, requestOptions));
+                return await doOperation(() => post(path, requestOptions));
             case "PUT":
-                return await doOperation(() => put(pathPrefix + targetPath, requestOptions));
+                return await doOperation(() => put(path, requestOptions));
             case "DELETE":
-                return await doOperation(() => destroy(pathPrefix + targetPath, requestOptions));
+                return await doOperation(() => destroy(path, requestOptions));
             default:
                 throw new Error("HTTP method not implemented");
         }

--- a/src/lib/helpers/api.ts
+++ b/src/lib/helpers/api.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { destroy, get, post, put } from "@/lib/helpers/requests";
 import { ChainIdentifier } from "@/types/chain";
+import { RequestOptions } from "@/types/requests";
 
 export function isUserMeFromContext(context: AppRouteHandlerFnContext): boolean {
     return userIdFromContext(context) === "me";
@@ -76,27 +77,25 @@ export function createGenericEndpoint(
             return respondNotFound();
         }
 
-        let body: BodyInit | undefined;
-        let contentType: string | null;
+        const requestOptions: RequestOptions = { accessToken };
         if (["POST", "PUT", "DELETE"].includes(method)) {
             if (options?.useFormData) {
-                body = await req.formData();
-                contentType = null;
+                requestOptions.body = await req.formData();
+                requestOptions.withContentType = "NO_CONTENT_TYPE";
             } else {
-                body = await req.text();
-                contentType = "application/json";
+                requestOptions.body = await req.text();
             }
         }
 
         switch (method) {
             case "GET":
-                return await doOperation(() => get(pathPrefix + targetPath, accessToken));
+                return await doOperation(() => get(pathPrefix + targetPath, requestOptions));
             case "POST":
-                return await doOperation(() => post(pathPrefix + targetPath, body, contentType, accessToken));
+                return await doOperation(() => post(pathPrefix + targetPath, requestOptions));
             case "PUT":
-                return await doOperation(() => put(pathPrefix + targetPath, body, contentType, accessToken));
+                return await doOperation(() => put(pathPrefix + targetPath, requestOptions));
             case "DELETE":
-                return await doOperation(() => destroy(pathPrefix + targetPath, body, contentType, accessToken));
+                return await doOperation(() => destroy(pathPrefix + targetPath, requestOptions));
             default:
                 throw new Error("HTTP method not implemented");
         }

--- a/src/lib/helpers/fetchers.ts
+++ b/src/lib/helpers/fetchers.ts
@@ -111,7 +111,6 @@ export async function fetchRezervoWeekSchedule(
                 `schedule/${chainIdentifier}/${weekOffset}${
                     locationIdentifiers.length > 0 ? `?location=${locationIdentifiers.join("&location=")}` : ""
                 }`,
-                { cache: "no-store" },
             )
         ).json()),
     }) as RezervoWeekSchedule;

--- a/src/lib/helpers/fetchers.ts
+++ b/src/lib/helpers/fetchers.ts
@@ -163,3 +163,9 @@ export function scheduleUrlKey(chainIdentifier: string, weekOffset: number, loca
         [...locationIds].sort(), // ensure cache hit with consistent ordering
     );
 }
+export async function postBookingRequest(chain: ChainIdentifier, classId: string, type: "book" | "cancel-booking") {
+    return await fetch(`/api/${chain}/${type}`, {
+        method: "POST",
+        body: JSON.stringify({ classId }, null, 2),
+    });
+}

--- a/src/lib/helpers/fetchers.ts
+++ b/src/lib/helpers/fetchers.ts
@@ -1,6 +1,6 @@
-import { get } from "@/lib/helpers/api";
 import { firstDateOfWeekByOffset } from "@/lib/helpers/date";
 import { createClassPopularityIndex } from "@/lib/helpers/popularity";
+import { get } from "@/lib/helpers/requests";
 import { deserializeWeekSchedule } from "@/lib/serialization/deserializers";
 import { serializeWeekSchedule } from "@/lib/serialization/serializers";
 import { ActivityCategory, ChainIdentifier, RezervoChain, RezervoSchedule, RezervoWeekSchedule } from "@/types/chain";
@@ -16,7 +16,7 @@ export function constructScheduleUrl(chainIdentifier: string, currentWeekOffset:
         ["weekOffset", currentWeekOffset.toString()],
         ...locationIds.map((locationId) => ["locationId", locationId]),
     ]);
-    return `/api/${chainIdentifier}/schedule?${searchParams.toString()}`;
+    return `${chainIdentifier}/schedule?${searchParams.toString()}`;
 }
 
 export async function fetchChainPageStaticProps(chain: RezervoChain): Promise<{
@@ -82,7 +82,7 @@ export async function fetchChainPageStaticProps(chain: RezervoChain): Promise<{
 }
 
 export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<RezervoChain> {
-    return get(`chains/${chainIdentifier}`).then((res) => {
+    return get(`chains/${chainIdentifier}`, undefined, true).then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch ${chainIdentifier} chain: ${res.statusText}`);
         }
@@ -91,7 +91,7 @@ export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<Reze
 }
 
 export async function fetchActiveChains(): Promise<RezervoChain[]> {
-    return get("chains").then((res) => {
+    return get("chains", undefined, true).then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch active chains: ${res.statusText}`);
         }
@@ -111,6 +111,8 @@ export async function fetchRezervoWeekSchedule(
                 `schedule/${chainIdentifier}/${weekOffset}${
                     locationIdentifiers.length > 0 ? `?location=${locationIdentifiers.join("&location=")}` : ""
                 }`,
+                undefined,
+                true,
             )
         ).json()),
     }) as RezervoWeekSchedule;
@@ -133,7 +135,7 @@ export async function fetchRezervoSchedule(
 }
 
 export async function fetchActivityCategories(): Promise<ActivityCategory[]> {
-    return get("categories").then((res) => {
+    return get("categories", undefined, true).then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch activity categories: ${res.statusText}`);
         }
@@ -151,10 +153,4 @@ export function scheduleUrlKey(chainIdentifier: string, weekOffset: number, loca
         weekOffset,
         [...locationIds].sort(), // ensure cache hit with consistent ordering
     );
-}
-export async function postBookingRequest(chain: ChainIdentifier, classId: string, type: "book" | "cancel-booking") {
-    return await fetch(`/api/${chain}/${type}`, {
-        method: "POST",
-        body: JSON.stringify({ classId }, null, 2),
-    });
 }

--- a/src/lib/helpers/fetchers.ts
+++ b/src/lib/helpers/fetchers.ts
@@ -82,7 +82,7 @@ export async function fetchChainPageStaticProps(chain: RezervoChain): Promise<{
 }
 
 export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<RezervoChain> {
-    return get(`chains/${chainIdentifier}`, undefined, true).then((res) => {
+    return get(`chains/${chainIdentifier}`).then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch ${chainIdentifier} chain: ${res.statusText}`);
         }
@@ -91,7 +91,7 @@ export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<Reze
 }
 
 export async function fetchActiveChains(): Promise<RezervoChain[]> {
-    return get("chains", undefined, true).then((res) => {
+    return get("chains").then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch active chains: ${res.statusText}`);
         }
@@ -111,8 +111,7 @@ export async function fetchRezervoWeekSchedule(
                 `schedule/${chainIdentifier}/${weekOffset}${
                     locationIdentifiers.length > 0 ? `?location=${locationIdentifiers.join("&location=")}` : ""
                 }`,
-                undefined,
-                true,
+                { cache: "no-store" },
             )
         ).json()),
     }) as RezervoWeekSchedule;
@@ -135,7 +134,7 @@ export async function fetchRezervoSchedule(
 }
 
 export async function fetchActivityCategories(): Promise<ActivityCategory[]> {
-    return get("categories", undefined, true).then((res) => {
+    return get("categories").then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch activity categories: ${res.statusText}`);
         }

--- a/src/lib/helpers/fetchers.ts
+++ b/src/lib/helpers/fetchers.ts
@@ -1,4 +1,4 @@
-import { buildBackendPath } from "@/lib/helpers/api";
+import { get } from "@/lib/helpers/api";
 import { firstDateOfWeekByOffset } from "@/lib/helpers/date";
 import { createClassPopularityIndex } from "@/lib/helpers/popularity";
 import { deserializeWeekSchedule } from "@/lib/serialization/deserializers";
@@ -82,9 +82,7 @@ export async function fetchChainPageStaticProps(chain: RezervoChain): Promise<{
 }
 
 export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<RezervoChain> {
-    return fetch(buildBackendPath(`chains/${chainIdentifier}`), {
-        cache: "no-store",
-    }).then((res) => {
+    return get(`chains/${chainIdentifier}`).then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch ${chainIdentifier} chain: ${res.statusText}`);
         }
@@ -93,9 +91,7 @@ export async function fetchChain(chainIdentifier: ChainIdentifier): Promise<Reze
 }
 
 export async function fetchActiveChains(): Promise<RezervoChain[]> {
-    return fetch(buildBackendPath("chains"), {
-        cache: "no-store",
-    }).then((res) => {
+    return get("chains").then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch active chains: ${res.statusText}`);
         }
@@ -111,15 +107,10 @@ export async function fetchRezervoWeekSchedule(
     return deserializeWeekSchedule({
         locationIds: locationIdentifiers,
         ...(await (
-            await fetch(
-                buildBackendPath(
-                    `schedule/${chainIdentifier}/${weekOffset}${
-                        locationIdentifiers.length > 0 ? `?location=${locationIdentifiers.join("&location=")}` : ""
-                    }`,
-                ),
-                {
-                    cache: "no-store",
-                },
+            await get(
+                `schedule/${chainIdentifier}/${weekOffset}${
+                    locationIdentifiers.length > 0 ? `?location=${locationIdentifiers.join("&location=")}` : ""
+                }`,
             )
         ).json()),
     }) as RezervoWeekSchedule;
@@ -142,9 +133,7 @@ export async function fetchRezervoSchedule(
 }
 
 export async function fetchActivityCategories(): Promise<ActivityCategory[]> {
-    return fetch(buildBackendPath("categories"), {
-        cache: "no-store",
-    }).then((res) => {
+    return get("categories").then((res) => {
         if (!res.ok) {
             throw new Error(`Failed to fetch activity categories: ${res.statusText}`);
         }

--- a/src/lib/helpers/requests.ts
+++ b/src/lib/helpers/requests.ts
@@ -1,0 +1,76 @@
+import { HTTP_METHOD } from "next/dist/server/web/http";
+
+function createRequestInit(
+    method: HTTP_METHOD,
+    accessToken?: string,
+    body?: BodyInit,
+    contentType: string | null = "application/json",
+    cache?: RequestCache,
+): RequestInit {
+    const headers = new Headers();
+    const requestInit: RequestInit = {
+        method,
+        headers,
+    };
+    if (accessToken) {
+        headers.append("Authorization", `Bearer ${accessToken}`);
+    }
+    if (contentType) {
+        headers.append("Content-Type", contentType);
+    }
+    if (body) {
+        requestInit.body = body;
+    }
+    if (cache) {
+        requestInit.cache = cache;
+    }
+    return requestInit;
+}
+
+function buildBackendPath(path: string): string {
+    const host = process.env["INTERNAL_CONFIG_HOST"] ?? process.env["NEXT_PUBLIC_CONFIG_HOST"];
+    return `${host}/${path}`;
+}
+
+export function buildBackendAuthProxyPath(path: string): string {
+    return `/api/${path}`;
+}
+
+function createRequest(path: string, requestInit: RequestInit, authProxyRequired?: boolean): Promise<Response> {
+    return fetch(authProxyRequired ? buildBackendAuthProxyPath(path) : buildBackendPath(path), requestInit);
+}
+
+export function get(path: string, accessToken?: string, skipAuthProxy?: boolean): Promise<Response> {
+    return createRequest(
+        path,
+        createRequestInit("GET", accessToken, undefined, undefined, "no-store"),
+        !accessToken && !skipAuthProxy,
+    );
+}
+
+export function put(
+    path: string,
+    body?: BodyInit,
+    contentType?: string | null,
+    accessToken?: string,
+): Promise<Response> {
+    return createRequest(path, createRequestInit("PUT", accessToken, body, contentType), !accessToken);
+}
+
+export function post(
+    path: string,
+    body?: BodyInit,
+    contentType?: string | null,
+    accessToken?: string,
+): Promise<Response> {
+    return createRequest(path, createRequestInit("POST", accessToken, body, contentType), !accessToken);
+}
+
+export function destroy(
+    path: string,
+    body?: BodyInit,
+    contentType?: string | null,
+    accessToken?: string,
+): Promise<Response> {
+    return createRequest(path, createRequestInit("DELETE", accessToken, body, contentType), !accessToken);
+}

--- a/src/lib/hooks/useAllConfigs.ts
+++ b/src/lib/hooks/useAllConfigs.ts
@@ -8,7 +8,7 @@ import { AllConfigsIndex } from "@/types/config";
 export function useAllConfigs(chain: ChainIdentifier) {
     const { user } = useUser();
 
-    const allConfigsApiUrl = `/api/${chain}/all-configs`;
+    const allConfigsApiUrl = `${chain}/all-configs`;
 
     const { data, error, isLoading, mutate } = useSWR<AllConfigsIndex>(
         user && chain ? allConfigsApiUrl : null,

--- a/src/lib/hooks/useChainUser.ts
+++ b/src/lib/hooks/useChainUser.ts
@@ -2,6 +2,7 @@ import { useUser } from "@auth0/nextjs-auth0/client";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
+import { put } from "@/lib/helpers/requests";
 import { useUserChainConfigs } from "@/lib/hooks/useUserChainConfigs";
 import { useUserConfig } from "@/lib/hooks/useUserConfig";
 import { fetcher } from "@/lib/utils/fetchUtils";
@@ -18,13 +19,10 @@ type ChainUserTotpFlowInitiatedResponse = {
     totpRegex: string;
 };
 
-type ChainUserMutationReponse = ChainUserUpdatedResponse | ChainUserTotpFlowInitiatedResponse;
+type ChainUserMutationResponse = ChainUserUpdatedResponse | ChainUserTotpFlowInitiatedResponse;
 
 async function putChainUser(url: string, chainUser: ChainUserPayload, dependantMutations: () => Promise<void>) {
-    const res = await fetch(url, {
-        method: "PUT",
-        body: JSON.stringify(chainUser, null, 2),
-    });
+    const res = await put(url, JSON.stringify(chainUser, null, 2));
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user");
@@ -34,10 +32,7 @@ async function putChainUser(url: string, chainUser: ChainUserPayload, dependantM
 }
 
 async function putChainUserTotp(url: string, totp: ChainUserTotpPayload, dependantMutations: () => Promise<void>) {
-    const res = await fetch(url, {
-        method: "PUT",
-        body: JSON.stringify(totp, null, 2),
-    });
+    const res = await put(url, JSON.stringify(totp, null, 2));
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user TOTP");
@@ -49,8 +44,8 @@ async function putChainUserTotp(url: string, totp: ChainUserTotpPayload, dependa
 export function useChainUser(chain: ChainIdentifier) {
     const { user } = useUser();
 
-    const chainUserApiUrl = `/api/${chain}/user`;
-    const chainUserTotpApiUrl = `/api/${chain}/user/totp`;
+    const chainUserApiUrl = `${chain}/user`;
+    const chainUserTotpApiUrl = `${chain}/user/totp`;
 
     const { data, error, isLoading, mutate } = useSWR<ChainUserProfile>(
         user && chain ? chainUserApiUrl : null,
@@ -65,7 +60,7 @@ export function useChainUser(chain: ChainIdentifier) {
         await mutateUserChainConfigs();
     };
 
-    const putChainUserMutation = useSWRMutation<ChainUserMutationReponse, unknown, string, ChainUserPayload>(
+    const putChainUserMutation = useSWRMutation<ChainUserMutationResponse, unknown, string, ChainUserPayload>(
         chainUserApiUrl,
         (url: string, { arg: chainUser }: { arg: ChainUserPayload }) =>
             putChainUser(url, chainUser, dependantMutations),

--- a/src/lib/hooks/useChainUser.ts
+++ b/src/lib/hooks/useChainUser.ts
@@ -22,7 +22,7 @@ type ChainUserTotpFlowInitiatedResponse = {
 type ChainUserMutationResponse = ChainUserUpdatedResponse | ChainUserTotpFlowInitiatedResponse;
 
 async function putChainUser(url: string, chainUser: ChainUserPayload, dependantMutations: () => Promise<void>) {
-    const res = await put(url, { body: JSON.stringify(chainUser, null, 2), useAuthProxy: true });
+    const res = await put(url, { body: JSON.stringify(chainUser, null, 2), mode: "authProxy" });
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user");
@@ -32,7 +32,7 @@ async function putChainUser(url: string, chainUser: ChainUserPayload, dependantM
 }
 
 async function putChainUserTotp(url: string, totp: ChainUserTotpPayload, dependantMutations: () => Promise<void>) {
-    const res = await put(url, { body: JSON.stringify(totp, null, 2), useAuthProxy: true });
+    const res = await put(url, { body: JSON.stringify(totp, null, 2), mode: "authProxy" });
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user TOTP");

--- a/src/lib/hooks/useChainUser.ts
+++ b/src/lib/hooks/useChainUser.ts
@@ -22,7 +22,7 @@ type ChainUserTotpFlowInitiatedResponse = {
 type ChainUserMutationResponse = ChainUserUpdatedResponse | ChainUserTotpFlowInitiatedResponse;
 
 async function putChainUser(url: string, chainUser: ChainUserPayload, dependantMutations: () => Promise<void>) {
-    const res = await put(url, JSON.stringify(chainUser, null, 2));
+    const res = await put(url, { body: JSON.stringify(chainUser, null, 2), useAuthProxy: true });
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user");
@@ -32,7 +32,7 @@ async function putChainUser(url: string, chainUser: ChainUserPayload, dependantM
 }
 
 async function putChainUserTotp(url: string, totp: ChainUserTotpPayload, dependantMutations: () => Promise<void>) {
-    const res = await put(url, JSON.stringify(totp, null, 2));
+    const res = await put(url, { body: JSON.stringify(totp, null, 2), useAuthProxy: true });
     const data = await res.json();
     if (!res.ok) {
         throw new Error("An error occurred while updating chain user TOTP");

--- a/src/lib/hooks/useCommunity.ts
+++ b/src/lib/hooks/useCommunity.ts
@@ -13,7 +13,7 @@ function putRelationship(
 ) {
     return put(url, {
         body: JSON.stringify(relationship, null, 2),
-        useAuthProxy: true,
+        mode: "authProxy",
     }).then((r) => r.json());
 }
 

--- a/src/lib/hooks/useCommunity.ts
+++ b/src/lib/hooks/useCommunity.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
+import { put } from "@/lib/helpers/requests";
 import { fetcher } from "@/lib/utils/fetchUtils";
 import { RezervoCommunity, UserRelationship, UserRelationshipAction } from "@/types/community";
 
@@ -10,17 +11,14 @@ function putRelationship(
     url: string,
     { arg: relationship }: { arg: { userId: string; action: UserRelationshipAction } },
 ) {
-    return fetch(url, {
-        method: "PUT",
-        body: JSON.stringify(relationship, null, 2),
-    }).then((r) => r.json());
+    return put(url, JSON.stringify(relationship, null, 2)).then((r) => r.json());
 }
 
 export function useCommunity() {
     const { user } = useUser();
 
-    const communityApiUrl = `/api/community`;
-    const relationshipApiUrl = `/api/community/relationship`;
+    const communityApiUrl = `community`;
+    const relationshipApiUrl = `community/relationship`;
 
     const { data, error, isLoading, mutate } = useSWR<RezervoCommunity>(user ? communityApiUrl : null, fetcher);
 

--- a/src/lib/hooks/useCommunity.ts
+++ b/src/lib/hooks/useCommunity.ts
@@ -11,7 +11,10 @@ function putRelationship(
     url: string,
     { arg: relationship }: { arg: { userId: string; action: UserRelationshipAction } },
 ) {
-    return put(url, JSON.stringify(relationship, null, 2)).then((r) => r.json());
+    return put(url, {
+        body: JSON.stringify(relationship, null, 2),
+        useAuthProxy: true,
+    }).then((r) => r.json());
 }
 
 export function useCommunity() {

--- a/src/lib/hooks/useFeatures.ts
+++ b/src/lib/hooks/useFeatures.ts
@@ -7,7 +7,7 @@ import { Features } from "@/types/features";
 export function useFeatures() {
     const { user } = useUser();
 
-    const featuresApiUrl = `/api/features`;
+    const featuresApiUrl = `features`;
 
     const { data, error, isLoading } = useSWR<Features>(user ? featuresApiUrl : null, fetcher);
 

--- a/src/lib/hooks/usePreferences.ts
+++ b/src/lib/hooks/usePreferences.ts
@@ -7,7 +7,7 @@ import { fetcher } from "@/lib/utils/fetchUtils";
 import { Preferences, PreferencesPayload } from "@/types/config";
 
 function putPreferences(url: string, { arg: preferences }: { arg: PreferencesPayload }) {
-    return put(url, { body: JSON.stringify(preferences, null, 2), useAuthProxy: true }).then((r) => r.json());
+    return put(url, { body: JSON.stringify(preferences, null, 2), mode: "authProxy" }).then((r) => r.json());
 }
 
 export function usePreferences() {

--- a/src/lib/hooks/usePreferences.ts
+++ b/src/lib/hooks/usePreferences.ts
@@ -2,20 +2,18 @@ import { useUser } from "@auth0/nextjs-auth0/client";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
+import { put } from "@/lib/helpers/requests";
 import { fetcher } from "@/lib/utils/fetchUtils";
 import { Preferences, PreferencesPayload } from "@/types/config";
 
 function putPreferences(url: string, { arg: preferences }: { arg: PreferencesPayload }) {
-    return fetch(url, {
-        method: "PUT",
-        body: JSON.stringify(preferences, null, 2),
-    }).then((r) => r.json());
+    return put(url, JSON.stringify(preferences, null, 2)).then((r) => r.json());
 }
 
 export function usePreferences() {
     const { user } = useUser();
 
-    const preferencesApiUrl = `/api/preferences`;
+    const preferencesApiUrl = `preferences`;
 
     const { data, error, isLoading } = useSWR<Preferences>(user ? preferencesApiUrl : null, fetcher);
 

--- a/src/lib/hooks/usePreferences.ts
+++ b/src/lib/hooks/usePreferences.ts
@@ -7,7 +7,7 @@ import { fetcher } from "@/lib/utils/fetchUtils";
 import { Preferences, PreferencesPayload } from "@/types/config";
 
 function putPreferences(url: string, { arg: preferences }: { arg: PreferencesPayload }) {
-    return put(url, JSON.stringify(preferences, null, 2)).then((r) => r.json());
+    return put(url, { body: JSON.stringify(preferences, null, 2), useAuthProxy: true }).then((r) => r.json());
 }
 
 export function usePreferences() {

--- a/src/lib/hooks/usePushNotificationPublicKey.ts
+++ b/src/lib/hooks/usePushNotificationPublicKey.ts
@@ -6,7 +6,7 @@ import { fetcher } from "@/lib/utils/fetchUtils";
 export function usePushNotificationPublicKey() {
     const { user } = useUser();
 
-    const publicKeyApiUrl = `/api/notifications/push/public-key`;
+    const publicKeyApiUrl = `notifications/push/public-key`;
 
     const { data, error, isLoading } = useSWR<string>(user ? publicKeyApiUrl : null, fetcher);
 

--- a/src/lib/hooks/usePushNotificationSubscription.ts
+++ b/src/lib/hooks/usePushNotificationSubscription.ts
@@ -7,7 +7,7 @@ export function usePushNotificationSubscription() {
     const subscriptionVerifyApiUrl = `notifications/push/verify`;
 
     function subscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return put(url, JSON.stringify(subscription, null, 2)).then((r) => r.json());
+        return put(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.json());
     }
 
     const { trigger: triggerSubscribe, isMutating: isSubscribing } = useSWRMutation<
@@ -18,7 +18,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, subscribe);
 
     function unsubscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return destroy(url, JSON.stringify(subscription, null, 2)).then((r) => r.ok);
+        return destroy(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.ok);
     }
 
     const { trigger: triggerUnsubscribe, isMutating: isUnsubscribing } = useSWRMutation<
@@ -29,7 +29,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, unsubscribe);
 
     function verify(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return post(url, JSON.stringify(subscription, null, 2)).then((r) => r.json());
+        return post(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.json());
     }
 
     const { trigger: triggerVerify } = useSWRMutation<boolean, unknown, string, PushSubscription>(

--- a/src/lib/hooks/usePushNotificationSubscription.ts
+++ b/src/lib/hooks/usePushNotificationSubscription.ts
@@ -7,7 +7,7 @@ export function usePushNotificationSubscription() {
     const subscriptionVerifyApiUrl = `notifications/push/verify`;
 
     function subscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return put(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.json());
+        return put(url, { body: JSON.stringify(subscription, null, 2), mode: "authProxy" }).then((r) => r.json());
     }
 
     const { trigger: triggerSubscribe, isMutating: isSubscribing } = useSWRMutation<
@@ -18,7 +18,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, subscribe);
 
     function unsubscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return destroy(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.ok);
+        return destroy(url, { body: JSON.stringify(subscription, null, 2), mode: "authProxy" }).then((r) => r.ok);
     }
 
     const { trigger: triggerUnsubscribe, isMutating: isUnsubscribing } = useSWRMutation<
@@ -29,7 +29,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, unsubscribe);
 
     function verify(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return post(url, { body: JSON.stringify(subscription, null, 2), useAuthProxy: true }).then((r) => r.json());
+        return post(url, { body: JSON.stringify(subscription, null, 2), mode: "authProxy" }).then((r) => r.json());
     }
 
     const { trigger: triggerVerify } = useSWRMutation<boolean, unknown, string, PushSubscription>(

--- a/src/lib/hooks/usePushNotificationSubscription.ts
+++ b/src/lib/hooks/usePushNotificationSubscription.ts
@@ -1,14 +1,13 @@
 import useSWRMutation from "swr/mutation";
 
+import { destroy, post, put } from "@/lib/helpers/requests";
+
 export function usePushNotificationSubscription() {
-    const subscriptionApiUrl = `/api/notifications/push`;
-    const subscriptionVerifyApiUrl = `/api/notifications/push/verify`;
+    const subscriptionApiUrl = `notifications/push`;
+    const subscriptionVerifyApiUrl = `notifications/push/verify`;
 
     function subscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return fetch(url, {
-            method: "PUT",
-            body: JSON.stringify(subscription, null, 2),
-        }).then((r) => r.json());
+        return put(url, JSON.stringify(subscription, null, 2)).then((r) => r.json());
     }
 
     const { trigger: triggerSubscribe, isMutating: isSubscribing } = useSWRMutation<
@@ -19,10 +18,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, subscribe);
 
     function unsubscribe(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return fetch(url, {
-            method: "DELETE",
-            body: JSON.stringify(subscription, null, 2),
-        }).then((r) => r.ok);
+        return destroy(url, JSON.stringify(subscription, null, 2)).then((r) => r.ok);
     }
 
     const { trigger: triggerUnsubscribe, isMutating: isUnsubscribing } = useSWRMutation<
@@ -33,10 +29,7 @@ export function usePushNotificationSubscription() {
     >(subscriptionApiUrl, unsubscribe);
 
     function verify(url: string, { arg: subscription }: { arg: PushSubscription }) {
-        return fetch(url, {
-            method: "POST",
-            body: JSON.stringify(subscription, null, 2),
-        }).then((r) => r.json());
+        return post(url, JSON.stringify(subscription, null, 2)).then((r) => r.json());
     }
 
     const { trigger: triggerVerify } = useSWRMutation<boolean, unknown, string, PushSubscription>(

--- a/src/lib/hooks/useUserCalendarFeedUrl.ts
+++ b/src/lib/hooks/useUserCalendarFeedUrl.ts
@@ -6,15 +6,9 @@ import { fetcher } from "@/lib/utils/fetchUtils";
 export function useUserCalendarFeedUrl(includePast: boolean) {
     const { user } = useUser();
 
-    // `document.location` is used as a dummy origin, since URL only supports absolute paths
-    const userCalendarFeedTokenUrl = new URL("/api/cal-url", document.location.origin);
-    userCalendarFeedTokenUrl.searchParams.set("include_past", String(includePast));
+    const userCalendarFeedTokenUrl = `cal-url?include_past=${includePast}`;
 
-    const {
-        data: url,
-        error: urlError,
-        isLoading,
-    } = useSWR<string>(user ? userCalendarFeedTokenUrl.toString() : null, fetcher);
+    const { data: url, error: urlError, isLoading } = useSWR<string>(user ? userCalendarFeedTokenUrl : null, fetcher);
 
     return url != null && urlError == null
         ? {

--- a/src/lib/hooks/useUserChainConfigs.ts
+++ b/src/lib/hooks/useUserChainConfigs.ts
@@ -8,7 +8,7 @@ import { ChainConfig } from "@/types/config";
 export function useUserChainConfigs() {
     const { user } = useUser();
 
-    const userChainConfigsApiUrl = `/api/user/chain-configs`;
+    const userChainConfigsApiUrl = `user/chain-configs`;
 
     const { data, error, isLoading, mutate } = useSWR<Record<ChainIdentifier, ChainConfig>>(
         user ? userChainConfigsApiUrl : null,

--- a/src/lib/hooks/useUserConfig.ts
+++ b/src/lib/hooks/useUserConfig.ts
@@ -15,7 +15,7 @@ async function putConfig(
     { arg: config }: { arg: ChainConfigPayload },
     dependantMutations: () => Promise<unknown[]>,
 ) {
-    const r = await put(url, { body: JSON.stringify(config, null, 2), useAuthProxy: true });
+    const r = await put(url, { body: JSON.stringify(config, null, 2), mode: "authProxy" });
     await dependantMutations();
     return await r.json();
 }

--- a/src/lib/hooks/useUserConfig.ts
+++ b/src/lib/hooks/useUserConfig.ts
@@ -2,6 +2,7 @@ import { useUser } from "@auth0/nextjs-auth0/client";
 import useSWR from "swr";
 import useSWRMutation from "swr/mutation";
 
+import { put } from "@/lib/helpers/requests";
 import { useAllConfigs } from "@/lib/hooks/useAllConfigs";
 import { useUserChainConfigs } from "@/lib/hooks/useUserChainConfigs";
 import { useUserSessions } from "@/lib/hooks/useUserSessions";
@@ -14,10 +15,7 @@ async function putConfig(
     { arg: config }: { arg: ChainConfigPayload },
     dependantMutations: () => Promise<unknown[]>,
 ) {
-    const r = await fetch(url, {
-        method: "PUT",
-        body: JSON.stringify(config, null, 2),
-    });
+    const r = await put(url, JSON.stringify(config, null, 2));
     await dependantMutations();
     return await r.json();
 }
@@ -25,7 +23,7 @@ async function putConfig(
 export function useUserConfig(chain: ChainIdentifier) {
     const { user } = useUser();
 
-    const configApiUrl = `/api/${chain}/config`;
+    const configApiUrl = `${chain}/config`;
 
     const { allConfigsIndex, mutateAllConfigs } = useAllConfigs(chain);
     const { mutateUserSessions } = useUserSessions();

--- a/src/lib/hooks/useUserConfig.ts
+++ b/src/lib/hooks/useUserConfig.ts
@@ -15,7 +15,7 @@ async function putConfig(
     { arg: config }: { arg: ChainConfigPayload },
     dependantMutations: () => Promise<unknown[]>,
 ) {
-    const r = await put(url, JSON.stringify(config, null, 2));
+    const r = await put(url, { body: JSON.stringify(config, null, 2), useAuthProxy: true });
     await dependantMutations();
     return await r.json();
 }

--- a/src/lib/hooks/useUserSessions.ts
+++ b/src/lib/hooks/useUserSessions.ts
@@ -8,7 +8,7 @@ import { BaseUserSessionDTO } from "@/types/serialization";
 export function useUserSessions() {
     const { user } = useUser();
 
-    const userSessionsApiUrl = `/api/user/sessions`;
+    const userSessionsApiUrl = `user/sessions`;
 
     const { data, mutate } = useSWR<BaseUserSessionDTO[]>(user ? userSessionsApiUrl : null, fetcher);
 

--- a/src/lib/hooks/useUserSessionsIndex.ts
+++ b/src/lib/hooks/useUserSessionsIndex.ts
@@ -8,7 +8,7 @@ import { UserSessionsIndex } from "@/types/userSessions";
 export function useUserSessionsIndex(chain: ChainIdentifier) {
     const { user } = useUser();
 
-    const userSessionsIndexApiUrl = `/api/${chain}/sessions-index`;
+    const userSessionsIndexApiUrl = `${chain}/sessions-index`;
 
     const { data, error, isLoading, mutate } = useSWR<UserSessionsIndex>(
         user && chain ? userSessionsIndexApiUrl : null,

--- a/src/lib/utils/fetchUtils.ts
+++ b/src/lib/utils/fetchUtils.ts
@@ -1,7 +1,7 @@
 import { createRequest } from "@/lib/helpers/requests";
 
 export const fetcher = async <TData>(path: string, init?: RequestInit): Promise<TData> => {
-    const r = await createRequest(path, init, { useAuthProxy: true });
+    const r = await createRequest(path, init, { mode: "authProxy" });
     if (r.ok) {
         return r.json();
     }

--- a/src/lib/utils/fetchUtils.ts
+++ b/src/lib/utils/fetchUtils.ts
@@ -1,5 +1,7 @@
-export const fetcher = async <TData>(key: RequestInfo | URL, init?: RequestInit): Promise<TData> => {
-    const r = await fetch(key, init);
+import { buildBackendAuthProxyPath } from "@/lib/helpers/requests";
+
+export const fetcher = async <TData>(path: string, init?: RequestInit): Promise<TData> => {
+    const r = await fetch(buildBackendAuthProxyPath(path), init);
     if (r.ok) {
         return r.json();
     }

--- a/src/lib/utils/fetchUtils.ts
+++ b/src/lib/utils/fetchUtils.ts
@@ -1,7 +1,7 @@
-import { buildBackendAuthProxyPath } from "@/lib/helpers/requests";
+import { createRequest } from "@/lib/helpers/requests";
 
 export const fetcher = async <TData>(path: string, init?: RequestInit): Promise<TData> => {
-    const r = await fetch(buildBackendAuthProxyPath(path), init);
+    const r = await createRequest(path, init, { useAuthProxy: true });
     if (r.ok) {
         return r.json();
     }

--- a/src/pages/[chain].tsx
+++ b/src/pages/[chain].tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo } from "react";
 import { Middleware, SWRConfig, useSWRConfig } from "swr";
 
 import Chain from "@/components/Chain";
+import PageHead from "@/components/utils/PageHead";
 import { fetchActiveChains, fetchChain, fetchChainPageStaticProps } from "@/lib/helpers/fetchers";
 import { storeSelectedChain } from "@/lib/helpers/storage";
 import { ChainPageParams } from "@/types/chain";
@@ -106,6 +107,7 @@ const ChainPage: NextPage<ChainPageProps> = ({
                 use: [scheduleFetchMiddleware],
             }}
         >
+            <PageHead title={`${chain.profile.identifier}-rezervo`} />
             <SWRCacheInjector<RezervoWeekScheduleDTO> cacheData={swrPrefetched} />
             <Chain
                 classPopularityIndex={classPopularityIndex}

--- a/src/pages/[chain].tsx
+++ b/src/pages/[chain].tsx
@@ -33,7 +33,7 @@ export async function getStaticProps({ params }: { params: ChainPageParams }): P
  */
 const scheduleFetchMiddleware: Middleware = (useSWRNext) => (key, fetcher, config) => {
     // ignore non-schedule keys
-    if (!(typeof key === "string" && key.match(/^\/api\/[a-z0-9-]+\/schedule/))) {
+    if (!(typeof key === "string" && key.match(/^[a-z0-9-]+\/schedule/))) {
         return useSWRNext(key, fetcher, config);
     }
     const { cache } = useSWRConfig();

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -1,0 +1,7 @@
+export type RequestOptions = {
+    accessToken?: string | undefined;
+    body?: BodyInit | undefined;
+    cache?: RequestCache;
+    withContentType?: string | "NO_CONTENT_TYPE";
+    useAuthProxy?: boolean;
+};

--- a/src/types/requests.ts
+++ b/src/types/requests.ts
@@ -1,7 +1,9 @@
+export type RequestMode = "client" | "server" | "authProxy";
+
 export type RequestOptions = {
     accessToken?: string | undefined;
     body?: BodyInit | undefined;
     cache?: RequestCache;
     withContentType?: string | "NO_CONTENT_TYPE";
-    useAuthProxy?: boolean;
+    mode?: RequestMode;
 };


### PR DESCRIPTION
This PR removes the duplication of the Next API endpoint logic. The goal is to make the Next API as slim and generic as possible, so it just acts as a proxy for authentication with Auth0. This way, it will be easier to create more similar endpoints, and we are nudged to write actual server-side logic in the FastAPI backend.

To achieve this, I abstracted the fetch functions into `utils/requests.ts` and made a generic API generator in `utils/api.ts`. This way, we have configurable fetch functions that can be configured to send requests via the auth proxy or directly to the actual backend.