### PR TITLE
Add PWA Install Button to Settings

### DIFF
--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -1,7 +1,6 @@
-import { PWAInstallElement } from "@khmyznikov/pwa-install";
 import { Box, Divider, Stack } from "@mui/material";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import ConfigBar from "@/components/configuration/ConfigBar";
 import AgendaModal from "@/components/modals/Agenda/AgendaModal";
@@ -19,12 +18,7 @@ import PWAInstallPrompt from "@/components/utils/PWAInstallPrompt";
 import { CLASS_ID_QUERY_PARAM, ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
 import { compactISOWeekString, LocalizedDateTime } from "@/lib/helpers/date";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
-import {
-    getStoredPWAInstallDismissed,
-    getStoredSelectedCategories,
-    getStoredSelectedLocations,
-    storePWAInstallDismissed,
-} from "@/lib/helpers/storage";
+import { getStoredSelectedCategories, getStoredSelectedLocations } from "@/lib/helpers/storage";
 import { useSchedule } from "@/lib/hooks/useSchedule";
 import { useUserChainConfigs } from "@/lib/hooks/useUserChainConfigs";
 import { useUserConfig } from "@/lib/hooks/useUserConfig";
@@ -228,29 +222,8 @@ function Chain({
         await mutateUserConfig();
     }, [mutateUserConfig]);
 
-    const pwaInstallRef = useRef<PWAInstallElement | null>(null);
-
-    // @ts-expect-error https://github.com/khmyznikov/pwa-install?tab=readme-ov-file#supported-properties-readonly
-    const isPWAInstalled = pwaInstallRef.current?.isUnderStandaloneMode === true;
-    const [isFirstTimeUsingPWA, setIsFirstTimeUsingPWA] = useState(false);
-
-    useEffect(() => {
-        pwaInstallRef.current?.addEventListener("pwa-install-available-event", () => {
-            if (getStoredPWAInstallDismissed()) {
-                pwaInstallRef.current?.hideDialog();
-            }
-        });
-        pwaInstallRef.current?.addEventListener("pwa-user-choice-result-event", (event) => {
-            // @ts-expect-error Missing type in @khmyznikov/pwa-install
-            if (event.detail.message === "dismissed") {
-                storePWAInstallDismissed();
-            }
-        });
-        // isUnderStandaloneMode is not updated the first time Chrome opens the PWA after install
-        pwaInstallRef.current?.addEventListener("pwa-install-success-event", () => {
-            setIsFirstTimeUsingPWA(true);
-        });
-    }, [pwaInstallRef]);
+    const [showPWAInstall, setShowPWAInstall] = useState(false);
+    const [isPWAInstalled, setIsPWAInstalled] = useState(false);
 
     return (
         <>
@@ -274,7 +247,6 @@ function Chain({
                             />
                         }
                     />
-                    <PWAInstallPrompt ref={pwaInstallRef} />
                     {error === undefined && currentWeekSchedule != null && (
                         <WeekNavigator
                             chain={chain}
@@ -332,8 +304,8 @@ function Chain({
                     setOpen={setIsSettingsOpen}
                     chainProfiles={chainProfiles}
                     chainConfigs={userChainConfigs}
-                    isPWAInstalled={isPWAInstalled || isFirstTimeUsingPWA}
-                    showPWAInstall={() => pwaInstallRef.current?.showDialog(true)}
+                    isPWAInstalled={isPWAInstalled}
+                    showPWAInstall={() => setShowPWAInstall(true)}
                 />
             )}
             <ProfileModal open={isProfileOpen} setOpen={setIsProfileOpen} />
@@ -345,6 +317,14 @@ function Chain({
                     action={bookingPopupState.action}
                 />
             )}
+            <PWAInstallPrompt
+                show={showPWAInstall}
+                onClose={() => setShowPWAInstall(false)}
+                onIsInstalledChanged={useCallback(
+                    (isInstalled: boolean) => setIsPWAInstalled(isInstalled),
+                    [setIsPWAInstalled],
+                )}
+            />
         </>
     );
 }

--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -1,6 +1,9 @@
-import { SettingsRounded } from "@mui/icons-material";
+import { GetApp, SettingsRounded } from "@mui/icons-material";
 import {
+    Alert,
+    AlertTitle,
     Box,
+    Button,
     CircularProgress,
     Divider,
     FormControl,
@@ -20,6 +23,7 @@ import React, { useEffect, useState } from "react";
 import CalendarFeed from "@/components/modals/Settings/CalendarFeed";
 import Memberships from "@/components/modals/Settings/Memberships/Memberships";
 import PushNotifications from "@/components/modals/Settings/PushNotifications";
+import { INSTALL_PROMPT_DESCRIPTION } from "@/components/utils/PWAInstallPrompt";
 import SlackSvgIcon from "@/components/utils/SlackSvgIcon";
 import { DEFAULT_REMINDER_HOURS, MAX_REMINDER_HOURS, MIN_REMINDER_HOURS } from "@/lib/consts";
 import { usePreferences } from "@/lib/hooks/usePreferences";
@@ -54,10 +58,14 @@ export default function Settings({
     chainProfiles,
     chainConfigs,
     features,
+    isPWAInstalled,
+    showPWAInstall,
 }: {
     chainProfiles: ChainProfile[];
     chainConfigs: Record<ChainIdentifier, ChainConfig>;
     features: Features | undefined;
+    isPWAInstalled: boolean;
+    showPWAInstall: () => void;
 }) {
     const theme = useTheme();
 
@@ -196,6 +204,19 @@ export default function Settings({
                 </Typography>
             </Box>
             <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                {!isPWAInstalled && (
+                    <>
+                        <Alert severity="info" icon={<GetApp />}>
+                            <AlertTitle>
+                                Installer <b>rezervo</b> som app
+                            </AlertTitle>
+                            {INSTALL_PROMPT_DESCRIPTION}
+                        </Alert>
+                        <Button color={"info"} variant={"outlined"} startIcon={<GetApp />} onClick={showPWAInstall}>
+                            Kom i gang
+                        </Button>
+                    </>
+                )}
                 <Memberships chainProfiles={chainProfiles} chainConfigs={chainConfigs} />
                 <Divider sx={{ mt: 1 }} />
                 <PushNotifications />

--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -213,7 +213,7 @@ export default function Settings({
                             {INSTALL_PROMPT_DESCRIPTION}
                         </Alert>
                         <Button color={"info"} variant={"outlined"} startIcon={<GetApp />} onClick={showPWAInstall}>
-                            Kom i gang
+                            Installer
                         </Button>
                     </>
                 )}

--- a/src/components/modals/Settings/SettingsModal.tsx
+++ b/src/components/modals/Settings/SettingsModal.tsx
@@ -11,18 +11,28 @@ const SettingsModal = ({
     setOpen,
     chainProfiles,
     chainConfigs,
+    isPWAInstalled,
+    showPWAInstall,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
     chainProfiles: ChainProfile[];
     chainConfigs: Record<ChainIdentifier, ChainConfig>;
+    isPWAInstalled: boolean;
+    showPWAInstall: () => void;
 }) => {
     const { features } = useFeatures();
 
     return (
         <Modal open={open} onClose={() => setOpen(false)}>
             <>
-                <Settings chainProfiles={chainProfiles} chainConfigs={chainConfigs} features={features} />
+                <Settings
+                    chainProfiles={chainProfiles}
+                    chainConfigs={chainConfigs}
+                    features={features}
+                    isPWAInstalled={isPWAInstalled}
+                    showPWAInstall={showPWAInstall}
+                />
             </>
         </Modal>
     );

--- a/src/components/utils/PWAInstallPrompt.tsx
+++ b/src/components/utils/PWAInstallPrompt.tsx
@@ -1,14 +1,60 @@
 import { PWAInstallElement } from "@khmyznikov/pwa-install";
 import PWAInstall from "@khmyznikov/pwa-install/dist/pwa-install.react.js";
-import React, { forwardRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
+
+import { getStoredPWAInstallDismissed, storePWAInstallDismissed } from "@/lib/helpers/storage";
 
 export const INSTALL_PROMPT_DESCRIPTION =
     "Denne nettsiden har app-funksjonalitet. Legg den til på hjemskjermen for å få enklere tilgang og muligheten til å aktivere push-varsler for booking.";
 
-const PWAInstallPrompt = forwardRef<PWAInstallElement | null>((_, ref) => {
-    return <PWAInstall ref={ref} install-description={INSTALL_PROMPT_DESCRIPTION} />;
-});
+function PWAInstallPrompt({
+    show = true,
+    onClose = () => {},
+    onIsInstalledChanged = () => {},
+}: {
+    show?: boolean;
+    onClose?: () => void;
+    onIsInstalledChanged?: (isInstalled: boolean) => void;
+}) {
+    const pwaInstallRef = useRef<PWAInstallElement | null>(null);
 
-PWAInstallPrompt.displayName = "PWAInstallPrompt";
+    const [isFirstTimeUsingPWA, setIsFirstTimeUsingPWA] = useState(false);
+
+    useEffect(() => {
+        // @ts-expect-error https://github.com/khmyznikov/pwa-install?tab=readme-ov-file#supported-properties-readonly
+        const isPWAInstalled = pwaInstallRef.current?.isUnderStandaloneMode === true;
+
+        onIsInstalledChanged(isPWAInstalled || isFirstTimeUsingPWA);
+    }, [onIsInstalledChanged, isFirstTimeUsingPWA]);
+
+    useEffect(() => {
+        if (show) {
+            pwaInstallRef.current?.showDialog();
+        } else {
+            pwaInstallRef.current?.hideDialog();
+        }
+    }, [show]);
+
+    useEffect(() => {
+        pwaInstallRef.current?.addEventListener("pwa-install-available-event", () => {
+            if (getStoredPWAInstallDismissed()) {
+                pwaInstallRef.current?.hideDialog();
+            }
+        });
+        pwaInstallRef.current?.addEventListener("pwa-user-choice-result-event", (event) => {
+            // @ts-expect-error Missing type in @khmyznikov/pwa-install
+            if (event.detail.message === "dismissed") {
+                storePWAInstallDismissed();
+            }
+            onClose();
+        });
+        // isUnderStandaloneMode is not updated the first time Chrome opens the PWA after install
+        pwaInstallRef.current?.addEventListener("pwa-install-success-event", () => {
+            setIsFirstTimeUsingPWA(true);
+        });
+    }, [onClose]);
+
+    return <PWAInstall ref={pwaInstallRef} install-description={INSTALL_PROMPT_DESCRIPTION} />;
+}
 
 export default PWAInstallPrompt;

--- a/src/components/utils/PWAInstallPrompt.tsx
+++ b/src/components/utils/PWAInstallPrompt.tsx
@@ -1,0 +1,14 @@
+import { PWAInstallElement } from "@khmyznikov/pwa-install";
+import PWAInstall from "@khmyznikov/pwa-install/dist/pwa-install.react.js";
+import React, { forwardRef } from "react";
+
+export const INSTALL_PROMPT_DESCRIPTION =
+    "Denne nettsiden har app-funksjonalitet. Legg den til på hjemskjermen for å få enklere tilgang og muligheten til å aktivere push-varsler for booking.";
+
+const PWAInstallPrompt = forwardRef<PWAInstallElement | null>((_, ref) => {
+    return <PWAInstall ref={ref} install-description={INSTALL_PROMPT_DESCRIPTION} />;
+});
+
+PWAInstallPrompt.displayName = "PWAInstallPrompt";
+
+export default PWAInstallPrompt;

--- a/src/lib/helpers/storage.ts
+++ b/src/lib/helpers/storage.ts
@@ -5,6 +5,7 @@ import { ChainIdentifier } from "@/types/chain";
 const STORAGE_KEY_PREFIX = "rezervo.";
 const STORAGE_KEYS = {
     SELECTED_CHAIN: `${STORAGE_KEY_PREFIX}selectedChain`,
+    PWA_INSTALL_DISMISSED: `${STORAGE_KEY_PREFIX}pwaInstallDismissed`,
     selectedLocations: (chain: string) => `${STORAGE_KEY_PREFIX}selectedLocations.${chain}`,
     selectedCategories: (chain: string) => `${STORAGE_KEY_PREFIX}selectedCategories.${chain}`,
 };
@@ -20,6 +21,14 @@ export function storeSelectedChain(chain: ChainIdentifier) {
 
 export function getStoredSelectedChain(): ChainIdentifier | null {
     return getStoredValue<ChainIdentifier>(STORAGE_KEYS.SELECTED_CHAIN, false);
+}
+
+export function storePWAInstallDismissed() {
+    storeValue(STORAGE_KEYS.PWA_INSTALL_DISMISSED, true);
+}
+
+export function getStoredPWAInstallDismissed(): boolean | null {
+    return getStoredValue<boolean>(STORAGE_KEYS.PWA_INSTALL_DISMISSED, false);
 }
 
 export function storeSelectedLocations(chainIdentifier: string, locationIdentifiers: string[]) {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import PWAInstall from "@khmyznikov/pwa-install/dist/pwa-install.react.js";
 import { Box, Button, Divider, Typography, useTheme } from "@mui/material";
 import type { NextPage } from "next";
 import Link from "next/link";
@@ -8,6 +7,7 @@ import React, { useEffect, useState } from "react";
 import ChainLogo from "@/components/utils/ChainLogo";
 import ChainLogoSpinner from "@/components/utils/ChainLogoSpinner";
 import PageHead from "@/components/utils/PageHead";
+import PWAInstallPrompt from "@/components/utils/PWAInstallPrompt";
 import { fetchActiveChains } from "@/lib/helpers/fetchers";
 import { getStoredSelectedChain } from "@/lib/helpers/storage";
 import { ChainIdentifier } from "@/types/chain";
@@ -47,13 +47,7 @@ const IndexPage: NextPage<IndexPageProps> = ({ chainProfiles }) => {
     return (
         <>
             <PageHead title={"rezervo"} />
-            <PWAInstall
-                // TODO: make "pwa-hide-install" flag persist across sessions
-                install-description={
-                    "Denne nettsiden har app-funksjonalitet. Legg den til på hjemskjermen for å få enklere tilgang " +
-                    "og muligheten til å aktivere push-varsler for booking."
-                }
-            />
+            <PWAInstallPrompt />
             <Box
                 sx={{
                     display: "flex",


### PR DESCRIPTION
Currently, the install instructions for the PWA are only on the index page, and thus inaccessible if the user has already clicked one of the branches. (since we always redirect from the index once the users have selected a branch) This is a problem if those users want to install the app, as there is no easy way for them to see the instructions again. 

This PR adds an info box with a button in Settings that triggers the PWA install prompt. This info is only visible if the user has not installed the PWA.

This feature is a useful nudge for users to actually install rezervo as an app, and not just use it as a website. That way, they will hopefully enable push notifications and get fully integrated into the rezervo ecosystem 🤗 




https://github.com/mathiazom/rezervo-web/assets/26925695/cfaea547-f978-4345-98c6-6f7f78fff6a0




