### PR TITLE
Display Wait List Position

### DIFF
--- a/src/components/modals/Agenda/AgendaSession.tsx
+++ b/src/components/modals/Agenda/AgendaSession.tsx
@@ -159,12 +159,13 @@ export default function AgendaSession({
                                             color={"warning"}
                                             label={
                                                 userSession.positionInWaitList
-                                                    ? `Venteliste: ${userSession.positionInWaitList}`
+                                                    ? `Venteliste: ${userSession.positionInWaitList}.`
                                                     : "Venteliste"
                                             }
                                             icon={<HourglassTopRounded />}
                                             sx={{
-                                                marginY: "0.2rem",
+                                                marginTop: "0.5rem",
+                                                marginBottom: "0.2rem",
                                                 "& .MuiChip-icon": {
                                                     fontSize: "0.85rem",
                                                     marginLeft: "0.5rem",

--- a/src/components/modals/Agenda/AgendaSession.tsx
+++ b/src/components/modals/Agenda/AgendaSession.tsx
@@ -147,11 +147,21 @@ export default function AgendaSession({
                                     </Typography>
                                 )}
                                 {userSession?.status === SessionStatus.WAITLIST && (
-                                    <Tooltip title={"Du er på venteliste for denne timen"}>
+                                    <Tooltip
+                                        title={
+                                            userSession.positionInWaitList
+                                                ? `Du er nummer ${userSession.positionInWaitList} på venteliste for denne timen`
+                                                : "Du er på venteliste for denne timen"
+                                        }
+                                    >
                                         <Chip
                                             size={"small"}
                                             color={"warning"}
-                                            label={"Venteliste"}
+                                            label={
+                                                userSession.positionInWaitList
+                                                    ? `Venteliste: ${userSession.positionInWaitList}`
+                                                    : "Venteliste"
+                                            }
                                             icon={<HourglassTopRounded />}
                                             sx={{
                                                 marginY: "0.2rem",

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -205,7 +205,7 @@ export default function ClassInfo({
                                       ? ` (${positionedUsersInWaitList
                                             .map(
                                                 (u) =>
-                                                    `${u.isSelf ? "Din plassering" : u.userName}: ${u.positionInWaitList}`,
+                                                    `${u.isSelf ? "din plassering" : u.userName}: ${u.positionInWaitList}.`,
                                             )
                                             .join(", ")})`
                                       : "")

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -92,7 +92,7 @@ export default function ClassInfo({
         setBookingLoading(false);
     }
 
-    // We do not know their position in the wait list before the sessions are pulled
+    // We might not know their position in the wait list before the sessions are pulled, depending on provider implementation
     const positionedUsersInWaitList = usersOnWaitlist.filter((u) => u.positionInWaitList);
 
     return (

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -92,6 +92,9 @@ export default function ClassInfo({
         setBookingLoading(false);
     }
 
+    // We do not know their position in the wait list before the sessions are pulled
+    const positionedUsersInWaitList = usersOnWaitlist.filter((u) => u.positionInWaitList);
+
     return (
         <Box
             sx={{
@@ -197,7 +200,15 @@ export default function ClassInfo({
                         text={
                             _class.isCancelled
                                 ? "var på venteliste for denne timen"
-                                : "er på venteliste for denne timen"
+                                : "er på venteliste for denne timen" +
+                                  (positionedUsersInWaitList.length > 0
+                                      ? ` (${positionedUsersInWaitList
+                                            .map(
+                                                (u) =>
+                                                    `${u.isSelf ? "Din plassering" : u.userName}: ${u.positionInWaitList}`,
+                                            )
+                                            .join(", ")})`
+                                      : "")
                         }
                     />
                 </>

--- a/src/types/serialization.ts
+++ b/src/types/serialization.ts
@@ -39,5 +39,6 @@ export type IndexPageProps = {
 export type BaseUserSessionDTO = {
     chain: ChainIdentifier;
     status: SessionStatus;
+    positionInWaitList: number | null;
     classData: RezervoClassDTO;
 };

--- a/src/types/userSessions.ts
+++ b/src/types/userSessions.ts
@@ -18,6 +18,7 @@ export enum StatusColors {
 
 export type UserNameSessionStatus = UserNameWithIsSelf & {
     status: SessionStatus;
+    positionInWaitList: number | null;
 };
 export type UserSessionsIndex = {
     [classId: string]: UserNameSessionStatus[];
@@ -26,5 +27,6 @@ export type UserSessionsIndex = {
 export type BaseUserSession = {
     chain: ChainIdentifier;
     status: SessionStatus;
+    positionInWaitList: number | null;
     classData: RezervoClass;
 };


### PR DESCRIPTION
This PR displays a user's position in wait lists provided by https://github.com/mathiazom/rezervo/pull/56

~~One note is that immediately after booking, their position is not provided by the backend, since the booking requests do not wait for session pulling before returning. A future improvement could be to extract the booking status/wait list position from each provider's response to a booking request, but I think it is fine to just display the position once session pulling is complete.~~

> Updated. 🚀  See the [latest comment](https://github.com/mathiazom/rezervo-web/pull/137#issuecomment-2111113395)

#### Agenda
<img width="657" alt="Screenshot 2024-05-13 at 23 51 57" src="https://github.com/mathiazom/rezervo-web/assets/26925695/e5e97ceb-ade1-4bbd-9872-ed21f5cb931b">

#### Class Info
<img width="657" alt="Screenshot 2024-05-13 at 23 42 01" src="https://github.com/mathiazom/rezervo-web/assets/26925695/2956934a-07ff-42bf-8855-41d255d45266">
