### PR TITLE
Display Additional Info On ClassCard

### DIFF
--- a/src/components/schedule/class/ClassCard.tsx
+++ b/src/components/schedule/class/ClassCard.tsx
@@ -1,4 +1,4 @@
-import { CancelRounded, EventBusy, EventRepeat } from "@mui/icons-material";
+import { CancelRounded, EventBusy, EventRepeat, InfoOutlined } from "@mui/icons-material";
 import {
     AvatarGroup,
     Badge,
@@ -6,7 +6,9 @@ import {
     Card,
     CardActionArea,
     CardContent,
+    Chip,
     Collapse,
+    Stack,
     Tooltip,
     Typography,
 } from "@mui/material";
@@ -104,6 +106,7 @@ const ClassCard = ({
                 disableRipple
                 onClick={onInfo}
                 sx={{
+                    paddingBottom: 1,
                     opacity: isInThePast || _class.isCancelled ? 0.5 : 1,
                     background: "none",
                     position: "relative",
@@ -134,139 +137,158 @@ const ClassCard = ({
                 <CardContent
                     sx={{
                         zIndex: 1,
-                        position: "relative",
-                        display: "flex",
-                        justifyContent: "space-between",
-                        "&:last-child": {
-                            paddingBottom: 2,
-                        },
+                        paddingX: 1,
+                        paddingBottom: 1,
                     }}
                 >
-                    <Box sx={{ minWidth: 0 }}>
-                        <Typography
-                            sx={{
-                                textDecoration: isInThePast || _class.isCancelled ? "line-through" : "none",
-                                fontSize: "1.05rem",
-                                hyphens: "auto",
-                                ...(showSelected ? { fontWeight: "bold" } : {}),
-                            }}
-                        >
-                            {_class.activity.name}
-                        </Typography>
-                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                            {_class.startTime.toFormat("HH:mm")} - {_class.endTime.toFormat("HH:mm")}
-                        </Typography>
-                        <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                            {_class.location.studio}
-                        </Typography>
-                        {_class.instructors.length > 0 && (
-                            <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
-                                {formatInstructorNames(_class.instructors)}
+                    <Box
+                        sx={{
+                            position: "relative",
+                            display: "flex",
+                            justifyContent: "space-between",
+                            paddingX: 1,
+                        }}
+                    >
+                        <Box sx={{ minWidth: 0 }}>
+                            <Typography
+                                sx={{
+                                    textDecoration: isInThePast || _class.isCancelled ? "line-through" : "none",
+                                    fontSize: "1.05rem",
+                                    hyphens: "auto",
+                                    ...(showSelected ? { fontWeight: "bold" } : {}),
+                                }}
+                            >
+                                {_class.activity.name}
                             </Typography>
-                        )}
-                        <Collapse in={showUsersPlanned}>
-                            <Box pl={0.75} pt={1}>
-                                <AvatarGroup
-                                    max={4}
-                                    sx={{
-                                        justifyContent: "start",
-                                        marginLeft: "auto",
-                                        "& .MuiAvatar-root": {
-                                            width: AVATAR_SIZE,
-                                            height: AVATAR_SIZE,
-                                            fontSize: 12,
-                                            borderColor: "white",
-                                            '[data-mui-color-scheme="dark"] &': {
-                                                borderColor: "#191919",
+                            <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                                {_class.startTime.toFormat("HH:mm")} - {_class.endTime.toFormat("HH:mm")}
+                            </Typography>
+                            <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                                {_class.location.studio}
+                            </Typography>
+                            {_class.instructors.length > 0 && (
+                                <Typography sx={{ fontSize: "0.85rem" }} variant="body2" color="text.secondary">
+                                    {formatInstructorNames(_class.instructors)}
+                                </Typography>
+                            )}
+                            <Collapse in={showUsersPlanned}>
+                                <Box pl={0.75} pt={1}>
+                                    <AvatarGroup
+                                        max={4}
+                                        sx={{
+                                            justifyContent: "start",
+                                            marginLeft: "auto",
+                                            "& .MuiAvatar-root": {
+                                                width: AVATAR_SIZE,
+                                                height: AVATAR_SIZE,
+                                                fontSize: 12,
+                                                borderColor: "white",
+                                                '[data-mui-color-scheme="dark"] &': {
+                                                    borderColor: "#191919",
+                                                },
                                             },
-                                        },
-                                    }}
-                                >
-                                    {!isInThePast &&
-                                        usersPlanned.length > 0 &&
-                                        usersPlanned.map(({ userId, userName }) => (
-                                            <ClassUserAvatar
-                                                key={userId}
-                                                userId={userId}
-                                                username={userName}
-                                                size={AVATAR_SIZE}
-                                                badgeIcon={
-                                                    _class.isBookable ? <PlannedNotBookedBadgeIcon /> : undefined
-                                                }
-                                                loading={userSessionsLoading}
-                                            />
-                                        ))}
-                                    {userSessions.length > 0 &&
-                                        userSessions.map(({ userId, userName, status }) => (
-                                            <Box key={userId}>
+                                        }}
+                                    >
+                                        {!isInThePast &&
+                                            usersPlanned.length > 0 &&
+                                            usersPlanned.map(({ userId, userName }) => (
                                                 <ClassUserAvatar
+                                                    key={userId}
                                                     userId={userId}
                                                     username={userName}
                                                     size={AVATAR_SIZE}
-                                                    invisibleBadge={isInThePast}
                                                     badgeIcon={
-                                                        status === SessionStatus.NOSHOW ? (
-                                                            <NoShowBadgeIcon />
-                                                        ) : undefined
+                                                        _class.isBookable ? <PlannedNotBookedBadgeIcon /> : undefined
                                                     }
-                                                    rippleColor={
-                                                        status === SessionStatus.BOOKED ||
-                                                        status === SessionStatus.CONFIRMED
-                                                            ? StatusColors.ACTIVE
-                                                            : status === SessionStatus.WAITLIST
-                                                              ? StatusColors.WAITLIST
-                                                              : undefined
-                                                    }
+                                                    loading={userSessionsLoading}
                                                 />
-                                            </Box>
-                                        ))}
-                                </AvatarGroup>
-                            </Box>
-                        </Collapse>
-                    </Box>
-                    <Box sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", ml: 0.5 }}>
-                        {_class.isCancelled ? (
-                            <Tooltip title={"Timen er avlyst"}>
-                                <Badge
-                                    overlap={"circular"}
-                                    badgeContent={<CancelRounded fontSize={"small"} color={"error"} />}
-                                >
+                                            ))}
+                                        {userSessions.length > 0 &&
+                                            userSessions.map(({ userId, userName, status }) => (
+                                                <Box key={userId}>
+                                                    <ClassUserAvatar
+                                                        userId={userId}
+                                                        username={userName}
+                                                        size={AVATAR_SIZE}
+                                                        invisibleBadge={isInThePast}
+                                                        badgeIcon={
+                                                            status === SessionStatus.NOSHOW ? (
+                                                                <NoShowBadgeIcon />
+                                                            ) : undefined
+                                                        }
+                                                        rippleColor={
+                                                            status === SessionStatus.BOOKED ||
+                                                            status === SessionStatus.CONFIRMED
+                                                                ? StatusColors.ACTIVE
+                                                                : status === SessionStatus.WAITLIST
+                                                                  ? StatusColors.WAITLIST
+                                                                  : undefined
+                                                        }
+                                                    />
+                                                </Box>
+                                            ))}
+                                    </AvatarGroup>
+                                </Box>
+                            </Collapse>
+                        </Box>
+                        <Box
+                            sx={{ display: "flex", flexDirection: "column", justifyContent: "space-between", ml: 0.5 }}
+                        >
+                            {_class.isCancelled ? (
+                                <Tooltip title={"Timen er avlyst"}>
+                                    <Badge
+                                        overlap={"circular"}
+                                        badgeContent={<CancelRounded fontSize={"small"} color={"error"} />}
+                                    >
+                                        <ClassPopularityMeter _class={_class} historicPopularity={popularity} />
+                                    </Badge>
+                                </Tooltip>
+                            ) : (
+                                (_class.totalSlots !== null ||
+                                    (_class.isBookable && _class.waitingListCount !== null)) && (
                                     <ClassPopularityMeter _class={_class} historicPopularity={popularity} />
-                                </Badge>
-                            </Tooltip>
-                        ) : (
-                            (_class.totalSlots !== null || (_class.isBookable && _class.waitingListCount !== null)) && (
-                                <ClassPopularityMeter _class={_class} historicPopularity={popularity} />
-                            )
-                        )}
-                        {showScheduleAction && (
-                            <Tooltip
-                                title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}
-                                // Hide the tooltip when clicked
-                                open={showSelectClassTooltip}
-                                disableHoverListener
-                                onMouseEnter={() => setShowSelectClassTooltip(true)}
-                                onMouseLeave={() => setShowSelectClassTooltip(false)}
-                            >
-                                <IconButton
-                                    onClick={(event) => {
-                                        // Prevent onInfo()
-                                        event.stopPropagation();
-                                        selectClass();
-                                        setShowSelectClassTooltip(false);
-                                    }}
-                                    size={"small"}
-                                    sx={{
-                                        marginTop: "auto",
-                                        padding: 0,
-                                        height: 28, // to avoid jumping when avatars are displayed
-                                    }}
+                                )
+                            )}
+                            {showScheduleAction && (
+                                <Tooltip
+                                    title={(selected ? "Fjern fra" : "Legg til i") + " timeplan"}
+                                    // Hide the tooltip when clicked
+                                    open={showSelectClassTooltip}
+                                    disableHoverListener
+                                    onMouseEnter={() => setShowSelectClassTooltip(true)}
+                                    onMouseLeave={() => setShowSelectClassTooltip(false)}
                                 >
-                                    {selected ? <EventBusy /> : <EventRepeat />}
-                                </IconButton>
-                            </Tooltip>
-                        )}
+                                    <IconButton
+                                        onClick={(event) => {
+                                            // Prevent onInfo()
+                                            event.stopPropagation();
+                                            selectClass();
+                                            setShowSelectClassTooltip(false);
+                                        }}
+                                        size={"small"}
+                                        sx={{
+                                            marginTop: "auto",
+                                            padding: 0,
+                                            height: 28, // to avoid jumping when avatars are displayed
+                                        }}
+                                    >
+                                        {selected ? <EventBusy /> : <EventRepeat />}
+                                    </IconButton>
+                                </Tooltip>
+                            )}
+                        </Box>
                     </Box>
+                    {!isInThePast && _class.activity.additionalInformation && (
+                        <Tooltip title={_class.activity.additionalInformation}>
+                            <Stack mt={2}>
+                                <Chip
+                                    variant={"outlined"}
+                                    icon={<InfoOutlined color={"info"} />}
+                                    label={_class.activity.additionalInformation}
+                                />
+                            </Stack>
+                        </Tooltip>
+                    )}
                 </CardContent>
             </CardActionArea>
         </Card>


### PR DESCRIPTION
I have always envisioned the "Annet" category as something reserved for exciting events and special occasions. 
Previously, events that had additional info were automatically assigned to the "Annet" category. This worked well for FSC Ski and 3T Fossegrenda (the homies), because they only added additional info on special occasions (pop-up events). 

However, other locations (😤) use the additional info as a _regular_ thing. Therefore, the "Annet" category is watered with "boring" normal classes on a lot of locations.

So how can we make the "Annet" category a special unicorn again?

Well, we can display the additional info directly on the ClassCard. That way, we get notified that there is some interesting info about the class, as well as keeping the "Annet" category clean. 

## Before
<img width="1404" alt="Screenshot 2024-05-16 at 23 24 49" src="https://github.com/mathiazom/rezervo-web/assets/26925695/b02babcb-f0af-4318-b60e-0b3d588e088e">


## After
<img width="1404" alt="Screenshot 2024-05-16 at 23 24 56" src="https://github.com/mathiazom/rezervo-web/assets/26925695/f841a73b-a839-4341-9b3c-bb39aaa6a576">


> Since the additionalInfo is often long, it gets truncated. You can see the full text by hovering over the Chip, or opening the ClassInfo.


 

