### PR TITLE
HOTFIX(auth0): do not cache Auth0 paths in Serwist

### DIFF
--- a/src/serviceworker/index.ts
+++ b/src/serviceworker/index.ts
@@ -1,6 +1,5 @@
 import { defaultCache } from "@serwist/next/worker";
-import type { PrecacheEntry, SerwistGlobalConfig } from "serwist";
-import { Serwist } from "serwist";
+import { NetworkOnly, PrecacheEntry, SerwistGlobalConfig, Serwist } from "serwist";
 
 declare global {
     interface WorkerGlobalScope extends SerwistGlobalConfig {
@@ -42,12 +41,22 @@ self.addEventListener("notificationclick", (event) => {
     );
 });
 
+const routesToFilter = ["/api/auth/login", "/api/auth/callback", "/api/auth/logout", "/api/auth/me"];
+
 const serwist = new Serwist({
     precacheEntries: self.__SW_MANIFEST ?? [],
     skipWaiting: true,
     clientsClaim: true,
     navigationPreload: true,
-    runtimeCaching: defaultCache,
+    runtimeCaching: [
+        {
+            matcher({ sameOrigin, url }) {
+                return sameOrigin && routesToFilter.includes(url.pathname);
+            },
+            handler: new NetworkOnly(),
+        },
+        ...defaultCache,
+    ],
 });
 
 serwist.addEventListeners();


### PR DESCRIPTION
Ref. https://github.com/auth0/nextjs-auth0/issues/1754#issuecomment-2346672593

This resolves our issues with Auth0 not working in Safari (at least on my local machines).  
