### PR TITLE
Add exclude class time filters to hide classes at inconvenient times

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "@mui/icons-material": "^5.15.15",
         "@mui/lab": "^5.0.0-alpha.170",
         "@mui/material": "^5.15.15",
+        "@mui/x-date-pickers": "^7.18.0",
         "@serwist/next": "^9.0.1",
         "js-cookie": "^3.0.5",
         "luxon": "^3.4.4",

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -18,7 +18,7 @@ import { CLASS_ID_QUERY_PARAM, ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM }
 import { compactISOWeekString, LocalizedDateTime } from "@/lib/helpers/date";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
 import {
-    getStoredExcludedClassTimeFilters,
+    getStoredExcludeClassTimeFilters,
     getStoredSelectedCategories,
     getStoredSelectedLocations,
 } from "@/lib/helpers/storage";
@@ -84,7 +84,7 @@ function Chain({
 
     const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>(initialLocationIds);
     const [selectedCategories, setSelectedCategories] = useState<string[]>(activityCategories.map((ac) => ac.name));
-    const [excludedClassTimeFilters, setExcludedClassTimeFilters] = useState<ExcludeClassTimeFilter[]>([]);
+    const [excludeClassTimeFilters, setExcludeClassTimeFilters] = useState<ExcludeClassTimeFilter[]>([]);
     const [selectedChain, setSelectedChain] = useState<string | null>(null);
 
     const [weekParam, setWeekParam] = useQueryState(ISO_WEEK_QUERY_PARAM);
@@ -109,7 +109,7 @@ function Chain({
         setSelectedCategories(
             getStoredSelectedCategories(chain.profile.identifier) ?? activityCategories.map((ac) => ac.name),
         );
-        setExcludedClassTimeFilters(getStoredExcludedClassTimeFilters() ?? []);
+        setExcludeClassTimeFilters(getStoredExcludeClassTimeFilters() ?? []);
         setSelectedChain(chain.profile.identifier);
     }, [chain.profile.identifier, defaultLocationIds, activityCategories]);
 
@@ -261,8 +261,8 @@ function Chain({
                             allCategories={activityCategories}
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}
-                            excludedClassTimeFilters={excludedClassTimeFilters}
-                            setExcludedClassTimeFilters={setExcludedClassTimeFilters}
+                            excludeClassTimeFilters={excludeClassTimeFilters}
+                            setExcludeClassTimeFilters={setExcludeClassTimeFilters}
                         />
                     )}
                     <Divider orientation="horizontal" />
@@ -274,7 +274,7 @@ function Chain({
                             weekSchedule={currentWeekSchedule}
                             selectedLocationIds={selectedLocationIds}
                             selectedCategories={selectedCategories}
-                            excludedClassTimeFilters={excludedClassTimeFilters}
+                            excludeClassTimeFilters={excludeClassTimeFilters}
                             classPopularityIndex={classPopularityIndex}
                             selectable={userConfig != undefined && !userConfigError}
                             selectedClassIds={selectedClassIds}

--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -17,7 +17,11 @@ import ErrorMessage from "@/components/utils/ErrorMessage";
 import { CLASS_ID_QUERY_PARAM, ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
 import { compactISOWeekString, LocalizedDateTime } from "@/lib/helpers/date";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
-import { getStoredSelectedCategories, getStoredSelectedLocations } from "@/lib/helpers/storage";
+import {
+    getStoredExcludedClassTimeFilters,
+    getStoredSelectedCategories,
+    getStoredSelectedLocations,
+} from "@/lib/helpers/storage";
 import { useSchedule } from "@/lib/hooks/useSchedule";
 import { useUserChainConfigs } from "@/lib/hooks/useUserChainConfigs";
 import { useUserConfig } from "@/lib/hooks/useUserConfig";
@@ -29,6 +33,7 @@ import {
     BookingPopupAction,
     BookingPopupState,
     ChainProfile,
+    ExcludeClassTimeFilter,
     RezervoChain,
     RezervoClass,
     RezervoWeekSchedule,
@@ -79,6 +84,7 @@ function Chain({
 
     const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>(initialLocationIds);
     const [selectedCategories, setSelectedCategories] = useState<string[]>(activityCategories.map((ac) => ac.name));
+    const [excludedClassTimeFilters, setExcludedClassTimeFilters] = useState<ExcludeClassTimeFilter[]>([]);
     const [selectedChain, setSelectedChain] = useState<string | null>(null);
 
     const [weekParam, setWeekParam] = useQueryState(ISO_WEEK_QUERY_PARAM);
@@ -103,6 +109,7 @@ function Chain({
         setSelectedCategories(
             getStoredSelectedCategories(chain.profile.identifier) ?? activityCategories.map((ac) => ac.name),
         );
+        setExcludedClassTimeFilters(getStoredExcludedClassTimeFilters() ?? []);
         setSelectedChain(chain.profile.identifier);
     }, [chain.profile.identifier, defaultLocationIds, activityCategories]);
 
@@ -254,6 +261,8 @@ function Chain({
                             allCategories={activityCategories}
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}
+                            excludedClassTimeFilters={excludedClassTimeFilters}
+                            setExcludedClassTimeFilters={setExcludedClassTimeFilters}
                         />
                     )}
                     <Divider orientation="horizontal" />
@@ -265,6 +274,7 @@ function Chain({
                             weekSchedule={currentWeekSchedule}
                             selectedLocationIds={selectedLocationIds}
                             selectedCategories={selectedCategories}
+                            excludedClassTimeFilters={excludedClassTimeFilters}
                             classPopularityIndex={classPopularityIndex}
                             selectable={userConfig != undefined && !userConfigError}
                             selectedClassIds={selectedClassIds}

--- a/src/components/modals/ExcludeClassTimeFilters.tsx
+++ b/src/components/modals/ExcludeClassTimeFilters.tsx
@@ -1,0 +1,247 @@
+import { Add, DeleteForeverRounded, DeleteRounded, RemoveRounded } from "@mui/icons-material";
+import {
+    Box,
+    Button,
+    Divider,
+    FormControl,
+    FormGroup,
+    IconButton,
+    InputLabel,
+    MenuItem,
+    Select,
+    Stack,
+    Tooltip,
+    Typography,
+    useTheme,
+} from "@mui/material";
+import { TimePicker } from "@mui/x-date-pickers";
+import { DateTime } from "luxon";
+import React, { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
+
+import { getCapitalizedWeekdays } from "@/lib/helpers/date";
+import { storeExcludedClassTimeFilters } from "@/lib/helpers/storage";
+import { ExcludeClassTimeFilter } from "@/types/chain";
+
+export default function ExcludeClassTimeFilters({
+    excludedClassTimeFilters,
+    setExcludedClassTimeFilters,
+}: {
+    excludedClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+}) {
+    const theme = useTheme();
+
+    const weekdays = getCapitalizedWeekdays();
+    const [excludedClassTimeWeekday, setExcludedClassTimeWeekday] = useState<number>(1);
+    const [excludedClassTimeStartTime, setExcludedClassTimeStartTime] = useState<DateTime | null>(null);
+    const [excludedClassTimeEndTime, setExcludedClassTimeEndTime] = useState<DateTime | null>(null);
+    const [inputValid, setInputValid] = useState<boolean>(false);
+
+    const validateInput = useCallback(() => {
+        return (
+            excludedClassTimeWeekday >= 1 &&
+            excludedClassTimeWeekday <= 7 &&
+            excludedClassTimeStartTime?.isValid === true &&
+            excludedClassTimeEndTime?.isValid === true &&
+            excludedClassTimeStartTime < excludedClassTimeEndTime &&
+            !excludedClassTimeFilters.some(
+                (it) =>
+                    it.weekday === excludedClassTimeWeekday &&
+                    it.startHour === excludedClassTimeStartTime.hour &&
+                    it.startMinute === excludedClassTimeStartTime.minute &&
+                    it.endHour === excludedClassTimeEndTime.hour &&
+                    it.endMinute === excludedClassTimeEndTime.minute,
+            )
+        );
+    }, [excludedClassTimeFilters, excludedClassTimeWeekday, excludedClassTimeStartTime, excludedClassTimeEndTime]);
+
+    useEffect(() => {
+        setInputValid(validateInput());
+    }, [
+        validateInput,
+        excludedClassTimeFilters,
+        excludedClassTimeWeekday,
+        excludedClassTimeStartTime,
+        excludedClassTimeEndTime,
+    ]);
+
+    const addFilter = () => {
+        if (!validateInput()) {
+            console.log("input was null...");
+            return;
+        }
+
+        setExcludedClassTimeFilters((filters) => {
+            const newFilters = [
+                ...filters,
+                {
+                    weekday: excludedClassTimeWeekday,
+                    startHour: excludedClassTimeStartTime!.hour,
+                    startMinute: excludedClassTimeStartTime!.minute,
+                    endHour: excludedClassTimeEndTime!.hour,
+                    endMinute: excludedClassTimeEndTime!.minute,
+                },
+            ];
+            storeExcludedClassTimeFilters(newFilters);
+            return newFilters;
+        });
+    };
+
+    const removeFilter = (filter: ExcludeClassTimeFilter) => {
+        setExcludedClassTimeFilters((filters) => {
+            const newFilters = filters.filter((it) => it !== filter);
+            storeExcludedClassTimeFilters(newFilters);
+            return newFilters;
+        });
+    };
+
+    const clearFilters = () => {
+        setExcludedClassTimeFilters(() => {
+            const empty: ExcludeClassTimeFilter[] = [];
+            storeExcludedClassTimeFilters(empty);
+            return empty;
+        });
+    };
+
+    return (
+        <Stack
+            direction={"column"}
+            sx={{
+                px: { xs: 0.5, sm: 2 },
+                mt: 1,
+                mx: 3,
+            }}
+            gap={3}
+        >
+            <Stack gap={0.5}>
+                <Typography variant="h6" textAlign={"center"} sx={{ fontSize: 18 }}>
+                    Skjul tidsrom
+                </Typography>
+                <Typography
+                    variant="body2"
+                    textAlign={"center"}
+                    sx={{
+                        color: theme.palette.grey[600],
+                        fontSize: 14,
+                        mb: 1,
+                    }}
+                >
+                    Legg til tidsrom du vil skjule fra timeplanen.
+                </Typography>
+            </Stack>
+            <form
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    addFilter();
+                }}
+            >
+                <FormControl component="fieldset">
+                    <FormGroup sx={{ mt: 1 }}>
+                        <Stack direction={"column"} gap={2}>
+                            <InputLabel id="exclude-class-time-filter-weekday">Ukedag</InputLabel>
+                            <Select
+                                labelId="exclude-class-time-filter-weekday"
+                                id="exclude-class-time-select"
+                                value={excludedClassTimeWeekday}
+                                label="Ukedag"
+                                onChange={({ target: { value } }) => {
+                                    setExcludedClassTimeWeekday(() => value as number);
+                                }}
+                            >
+                                {weekdays.map((day, i) => (
+                                    <MenuItem key={i} value={i + 1}>
+                                        {day}
+                                    </MenuItem>
+                                ))}
+                            </Select>
+                            <Stack direction={"row"} gap={2} alignItems={"center"}>
+                                <TimePicker
+                                    label="Fra"
+                                    views={["hours", "minutes"]}
+                                    ampm={false}
+                                    value={excludedClassTimeStartTime}
+                                    onChange={(newValue) => setExcludedClassTimeStartTime(() => newValue)}
+                                />
+                                <RemoveRounded />
+                                <TimePicker
+                                    label="Til"
+                                    views={["hours", "minutes"]}
+                                    ampm={false}
+                                    value={excludedClassTimeEndTime}
+                                    onChange={(newValue) => setExcludedClassTimeEndTime(() => newValue)}
+                                />
+                            </Stack>
+                            <Stack direction={"row"} gap={1} justifyContent={"center"}>
+                                <Button
+                                    startIcon={<Add />}
+                                    variant={"outlined"}
+                                    type={"submit"}
+                                    disabled={!inputValid}
+                                    size="large"
+                                    fullWidth
+                                >
+                                    Skjul tidsrom
+                                </Button>
+                            </Stack>
+                        </Stack>
+                    </FormGroup>
+                </FormControl>
+            </form>
+            <Divider />
+            <Stack>
+                <Typography variant="h6" textAlign={"center"} sx={{ fontSize: 18 }}>
+                    Skjulte tidsrom
+                </Typography>
+                <Box sx={{ mt: 1 }}>
+                    {excludedClassTimeFilters
+                        .toSorted((a, b) => a.endHour * 60 + a.endMinute - (b.endHour * 60 + b.endMinute))
+                        .toSorted((a, b) => a.startHour * 60 + a.startMinute - (b.startHour * 60 + b.startMinute))
+                        .toSorted((a, b) => a.weekday - b.weekday)
+                        .map((filter) => (
+                            <Stack
+                                key={JSON.stringify(filter)}
+                                direction={"row"}
+                                alignItems={"center"}
+                                justifyContent={"space-between"}
+                            >
+                                <Typography>{weekdays[filter.weekday - 1]}</Typography>
+                                <Typography>
+                                    {filter.startHour.toFixed(0).padStart(2, "0")}:
+                                    {filter.startMinute.toFixed(0).padStart(2, "0")}
+                                    {" – "}
+                                    {filter.endHour.toFixed(0).padStart(2, "0")}:
+                                    {filter.endMinute.toFixed(0).padStart(2, "0")}
+                                </Typography>
+                                <Tooltip title="Fjern tidsrom">
+                                    <IconButton
+                                        onClick={(event) => {
+                                            event.preventDefault();
+                                            removeFilter(filter);
+                                        }}
+                                        sx={{ opacity: 0.5 }}
+                                    >
+                                        <DeleteRounded />
+                                    </IconButton>
+                                </Tooltip>
+                            </Stack>
+                        ))}
+                </Box>
+                {excludedClassTimeFilters.length === 0 ? (
+                    <Typography variant={"body2"} textAlign={"center"} sx={{ opacity: 0.6, fontStyle: "italic" }}>
+                        Du har ikke eksludert noen tidsrom.
+                    </Typography>
+                ) : (
+                    <Button
+                        startIcon={<DeleteForeverRounded />}
+                        variant={"outlined"}
+                        color={"error"}
+                        onClick={clearFilters}
+                        sx={{ mt: 2 }}
+                    >
+                        Fjern alle
+                    </Button>
+                )}
+            </Stack>
+        </Stack>
+    );
+}

--- a/src/components/modals/ExcludeClassTimeFilters.tsx
+++ b/src/components/modals/ExcludeClassTimeFilters.tsx
@@ -13,6 +13,7 @@ import {
     Typography,
     useTheme,
 } from "@mui/material";
+import Grid2 from "@mui/material/Unstable_Grid2";
 import { TimePicker } from "@mui/x-date-pickers";
 import { DateTime, HourNumbers, MinuteNumbers, WeekdayNumbers } from "luxon";
 import React, { Dispatch, SetStateAction, useCallback, useMemo, useState } from "react";
@@ -20,7 +21,6 @@ import React, { Dispatch, SetStateAction, useCallback, useMemo, useState } from 
 import { getCapitalizedWeekdays } from "@/lib/helpers/date";
 import { storeExcludeClassTimeFilters } from "@/lib/helpers/storage";
 import { ExcludeClassTimeFilter } from "@/types/chain";
-import Grid2 from "@mui/material/Unstable_Grid2";
 
 export default function ExcludeClassTimeFilters({
     excludeClassTimeFilters,
@@ -60,28 +60,22 @@ export default function ExcludeClassTimeFilters({
                 startMinute: excludeClassTimeStartTime.minute as MinuteNumbers,
                 endHour: excludeClassTimeEndTime.hour as HourNumbers,
                 endMinute: excludeClassTimeEndTime.minute as MinuteNumbers,
-            }
+            };
         } else {
-            return false
+            return false;
         }
     }, [excludeClassTimeFilters, excludeClassTimeWeekday, excludeClassTimeStartTime, excludeClassTimeEndTime]);
 
-    const inputValid = useMemo(
-        () => validateInput() !== false,
-        [validateInput]
-    )
+    const inputValid = useMemo(() => validateInput() !== false, [validateInput]);
 
     const addFilter = () => {
-        const validInput = validateInput()
+        const validInput = validateInput();
         if (validInput === false) {
             return;
         }
 
         setExcludeClassTimeFilters((filters) => {
-            const newFilters = [
-                ...filters,
-                validInput,
-            ];
+            const newFilters = [...filters, validInput];
             storeExcludeClassTimeFilters(newFilters);
             return newFilters;
         });
@@ -89,17 +83,17 @@ export default function ExcludeClassTimeFilters({
 
     const equalFilters = (a: ExcludeClassTimeFilter, b: ExcludeClassTimeFilter) => {
         return (
-            a.weekday === b.weekday
-            && a.startHour === b.startHour
-            && a.startMinute === b.startMinute
-            && a.endHour === b.endHour
-            && a.endMinute === b.endMinute
-        )
-    }
+            a.weekday === b.weekday &&
+            a.startHour === b.startHour &&
+            a.startMinute === b.startMinute &&
+            a.endHour === b.endHour &&
+            a.endMinute === b.endMinute
+        );
+    };
 
     const removeFilter = (filter: ExcludeClassTimeFilter) => {
         setExcludeClassTimeFilters((filters) => {
-            const newFilters = filters.filter((it) => !equalFilters(filter, it))
+            const newFilters = filters.filter((it) => !equalFilters(filter, it));
             storeExcludeClassTimeFilters(newFilters);
             return newFilters;
         });
@@ -117,8 +111,8 @@ export default function ExcludeClassTimeFilters({
         return filters
             .toSorted((a, b) => a.endHour * 60 + a.endMinute - (b.endHour * 60 + b.endMinute))
             .toSorted((a, b) => a.startHour * 60 + a.startMinute - (b.startHour * 60 + b.startMinute))
-            .toSorted((a, b) => a.weekday - b.weekday)
-    }
+            .toSorted((a, b) => a.weekday - b.weekday);
+    };
 
     return (
         <Stack
@@ -209,36 +203,35 @@ export default function ExcludeClassTimeFilters({
                     Skjulte tidsrom
                 </Typography>
                 <Grid2 container rowSpacing={1}>
-                    {toSortedFilters(excludeClassTimeFilters)
-                        .map((filter) => (
-                            <>
-                                <Grid2 xs={4} textAlign={"left"} alignContent={"center"}>
-                                    <Typography>{weekdays[filter.weekday - 1]}</Typography>
-                                </Grid2>
-                                <Grid2 xs={6} sm={4} textAlign={"center"} alignContent={"center"}>
-                                    <Typography>
-                                        {filter.startHour.toFixed(0).padStart(2, "0")}:
-                                        {filter.startMinute.toFixed(0).padStart(2, "0")}
-                                        {" – "}
-                                        {filter.endHour.toFixed(0).padStart(2, "0")}:
-                                        {filter.endMinute.toFixed(0).padStart(2, "0")}
-                                    </Typography>
-                                </Grid2>
-                                <Grid2 xs={2} sm={4} textAlign={"right"} alignContent={"center"}>
-                                    <Tooltip title="Fjern tidsrom">
-                                        <IconButton
-                                            onClick={(event) => {
-                                                event.preventDefault();
-                                                removeFilter(filter);
-                                            }}
-                                            sx={{ opacity: 0.5 }}
-                                        >
-                                            <DeleteRounded />
-                                        </IconButton>
-                                    </Tooltip>
-                                </Grid2>
-                            </>
-                        ))}
+                    {toSortedFilters(excludeClassTimeFilters).map((filter) => (
+                        <>
+                            <Grid2 xs={4} textAlign={"left"} alignContent={"center"}>
+                                <Typography>{weekdays[filter.weekday - 1]}</Typography>
+                            </Grid2>
+                            <Grid2 xs={6} sm={4} textAlign={"center"} alignContent={"center"}>
+                                <Typography>
+                                    {filter.startHour.toFixed(0).padStart(2, "0")}:
+                                    {filter.startMinute.toFixed(0).padStart(2, "0")}
+                                    {" – "}
+                                    {filter.endHour.toFixed(0).padStart(2, "0")}:
+                                    {filter.endMinute.toFixed(0).padStart(2, "0")}
+                                </Typography>
+                            </Grid2>
+                            <Grid2 xs={2} sm={4} textAlign={"right"} alignContent={"center"}>
+                                <Tooltip title="Fjern tidsrom">
+                                    <IconButton
+                                        onClick={(event) => {
+                                            event.preventDefault();
+                                            removeFilter(filter);
+                                        }}
+                                        sx={{ opacity: 0.5 }}
+                                    >
+                                        <DeleteRounded />
+                                    </IconButton>
+                                </Tooltip>
+                            </Grid2>
+                        </>
+                    ))}
                 </Grid2>
                 {excludeClassTimeFilters.length === 0 ? (
                     <Typography variant={"body2"} textAlign={"center"} sx={{ opacity: 0.6, fontStyle: "italic" }}>

--- a/src/components/modals/ExcludeClassTimeFilters.tsx
+++ b/src/components/modals/ExcludeClassTimeFilters.tsx
@@ -1,6 +1,5 @@
 import { Add, DeleteForeverRounded, DeleteRounded, RemoveRounded } from "@mui/icons-material";
 import {
-    Box,
     Button,
     Divider,
     FormControl,
@@ -16,66 +15,61 @@ import {
 } from "@mui/material";
 import { TimePicker } from "@mui/x-date-pickers";
 import { DateTime, HourNumbers, MinuteNumbers, WeekdayNumbers } from "luxon";
-import React, { Dispatch, SetStateAction, useCallback, useEffect, useState } from "react";
+import React, { Dispatch, SetStateAction, useCallback, useMemo, useState } from "react";
 
 import { getCapitalizedWeekdays } from "@/lib/helpers/date";
-import { storeExcludedClassTimeFilters } from "@/lib/helpers/storage";
+import { storeExcludeClassTimeFilters } from "@/lib/helpers/storage";
 import { ExcludeClassTimeFilter } from "@/types/chain";
+import Grid2 from "@mui/material/Unstable_Grid2";
 
 export default function ExcludeClassTimeFilters({
-    excludedClassTimeFilters,
-    setExcludedClassTimeFilters,
+    excludeClassTimeFilters,
+    setExcludeClassTimeFilters,
 }: {
-    excludedClassTimeFilters: ExcludeClassTimeFilter[];
-    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+    excludeClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
 }) {
     const theme = useTheme();
 
     const weekdays = getCapitalizedWeekdays();
-    const [excludedClassTimeWeekday, setExcludedClassTimeWeekday] = useState<number>(1);
-    const [excludedClassTimeStartTime, setExcludedClassTimeStartTime] = useState<DateTime | null>(null);
-    const [excludedClassTimeEndTime, setExcludedClassTimeEndTime] = useState<DateTime | null>(null);
-    const [inputValid, setInputValid] = useState<boolean>(false);
+    const [excludeClassTimeWeekday, setExcludeClassTimeWeekday] = useState<number>(1);
+    const [excludeClassTimeStartTime, setExcludeClassTimeStartTime] = useState<DateTime | null>(null);
+    const [excludeClassTimeEndTime, setExcludeClassTimeEndTime] = useState<DateTime | null>(null);
 
     const validateInput: () => false | ExcludeClassTimeFilter = useCallback(() => {
         if (
-            excludedClassTimeWeekday >= 1 &&
-            excludedClassTimeWeekday <= 7 &&
-            excludedClassTimeStartTime !== null &&
-            excludedClassTimeStartTime.isValid &&
-            excludedClassTimeEndTime !== null &&
-            excludedClassTimeEndTime.isValid &&
-            excludedClassTimeStartTime < excludedClassTimeEndTime &&
-            !excludedClassTimeFilters.some(
+            excludeClassTimeWeekday >= 1 &&
+            excludeClassTimeWeekday <= 7 &&
+            excludeClassTimeStartTime !== null &&
+            excludeClassTimeStartTime.isValid &&
+            excludeClassTimeEndTime !== null &&
+            excludeClassTimeEndTime.isValid &&
+            excludeClassTimeStartTime < excludeClassTimeEndTime &&
+            !excludeClassTimeFilters.some(
                 (it) =>
-                    it.weekday === excludedClassTimeWeekday &&
-                    it.startHour === excludedClassTimeStartTime.hour &&
-                    it.startMinute === excludedClassTimeStartTime.minute &&
-                    it.endHour === excludedClassTimeEndTime.hour &&
-                    it.endMinute === excludedClassTimeEndTime.minute,
+                    it.weekday === excludeClassTimeWeekday &&
+                    it.startHour === excludeClassTimeStartTime.hour &&
+                    it.startMinute === excludeClassTimeStartTime.minute &&
+                    it.endHour === excludeClassTimeEndTime.hour &&
+                    it.endMinute === excludeClassTimeEndTime.minute,
             )
         ) {
             return {
-                weekday: excludedClassTimeWeekday as WeekdayNumbers,
-                startHour: excludedClassTimeStartTime.hour as HourNumbers,
-                startMinute: excludedClassTimeStartTime.minute as MinuteNumbers,
-                endHour: excludedClassTimeEndTime.hour as HourNumbers,
-                endMinute: excludedClassTimeEndTime.minute as MinuteNumbers,
+                weekday: excludeClassTimeWeekday as WeekdayNumbers,
+                startHour: excludeClassTimeStartTime.hour as HourNumbers,
+                startMinute: excludeClassTimeStartTime.minute as MinuteNumbers,
+                endHour: excludeClassTimeEndTime.hour as HourNumbers,
+                endMinute: excludeClassTimeEndTime.minute as MinuteNumbers,
             }
         } else {
             return false
         }
-    }, [excludedClassTimeFilters, excludedClassTimeWeekday, excludedClassTimeStartTime, excludedClassTimeEndTime]);
+    }, [excludeClassTimeFilters, excludeClassTimeWeekday, excludeClassTimeStartTime, excludeClassTimeEndTime]);
 
-    useEffect(() => {
-        setInputValid(validateInput() !== false);
-    }, [
-        validateInput,
-        excludedClassTimeFilters,
-        excludedClassTimeWeekday,
-        excludedClassTimeStartTime,
-        excludedClassTimeEndTime,
-    ]);
+    const inputValid = useMemo(
+        () => validateInput() !== false,
+        [validateInput]
+    )
 
     const addFilter = () => {
         const validInput = validateInput()
@@ -83,28 +77,38 @@ export default function ExcludeClassTimeFilters({
             return;
         }
 
-        setExcludedClassTimeFilters((filters) => {
+        setExcludeClassTimeFilters((filters) => {
             const newFilters = [
                 ...filters,
                 validInput,
             ];
-            storeExcludedClassTimeFilters(newFilters);
+            storeExcludeClassTimeFilters(newFilters);
             return newFilters;
         });
     };
 
+    const equalFilters = (a: ExcludeClassTimeFilter, b: ExcludeClassTimeFilter) => {
+        return (
+            a.weekday === b.weekday
+            && a.startHour === b.startHour
+            && a.startMinute === b.startMinute
+            && a.endHour === b.endHour
+            && a.endMinute === b.endMinute
+        )
+    }
+
     const removeFilter = (filter: ExcludeClassTimeFilter) => {
-        setExcludedClassTimeFilters((filters) => {
-            const newFilters = filters.filter((it) => it !== filter);
-            storeExcludedClassTimeFilters(newFilters);
+        setExcludeClassTimeFilters((filters) => {
+            const newFilters = filters.filter((it) => !equalFilters(filter, it))
+            storeExcludeClassTimeFilters(newFilters);
             return newFilters;
         });
     };
 
     const clearFilters = () => {
-        setExcludedClassTimeFilters(() => {
+        setExcludeClassTimeFilters(() => {
             const empty: ExcludeClassTimeFilter[] = [];
-            storeExcludedClassTimeFilters(empty);
+            storeExcludeClassTimeFilters(empty);
             return empty;
         });
     };
@@ -155,11 +159,11 @@ export default function ExcludeClassTimeFilters({
                             <Select
                                 labelId="exclude-class-time-filter-weekday"
                                 id="exclude-class-time-select"
-                                value={excludedClassTimeWeekday}
+                                value={excludeClassTimeWeekday}
                                 label="Ukedag"
                                 onChange={({ target: { value } }) => {
                                     if (typeof value === "string") return;
-                                    setExcludedClassTimeWeekday(() => value);
+                                    setExcludeClassTimeWeekday(() => value);
                                 }}
                             >
                                 {weekdays.map((day, i) => (
@@ -172,15 +176,15 @@ export default function ExcludeClassTimeFilters({
                                 <TimePicker
                                     label="Fra"
                                     views={["hours", "minutes"]}
-                                    value={excludedClassTimeStartTime}
-                                    onChange={(newValue) => setExcludedClassTimeStartTime(newValue)}
+                                    value={excludeClassTimeStartTime}
+                                    onChange={(newValue) => setExcludeClassTimeStartTime(newValue)}
                                 />
                                 <RemoveRounded />
                                 <TimePicker
                                     label="Til"
                                     views={["hours", "minutes"]}
-                                    value={excludedClassTimeEndTime}
-                                    onChange={(newValue) => setExcludedClassTimeEndTime(newValue)}
+                                    value={excludeClassTimeEndTime}
+                                    onChange={(newValue) => setExcludeClassTimeEndTime(newValue)}
                                 />
                             </Stack>
                             <Stack direction={"row"} gap={1} justifyContent={"center"}>
@@ -204,38 +208,39 @@ export default function ExcludeClassTimeFilters({
                 <Typography variant="h6" textAlign={"center"} sx={{ fontSize: 18 }}>
                     Skjulte tidsrom
                 </Typography>
-                <Box sx={{ mt: 1 }}>
-                    {toSortedFilters(excludedClassTimeFilters)
+                <Grid2 container rowSpacing={1}>
+                    {toSortedFilters(excludeClassTimeFilters)
                         .map((filter) => (
-                            <Stack
-                                key={JSON.stringify(filter)}
-                                direction={"row"}
-                                alignItems={"center"}
-                                justifyContent={"space-between"}
-                            >
-                                <Typography>{weekdays[filter.weekday - 1]}</Typography>
-                                <Typography>
-                                    {filter.startHour.toFixed(0).padStart(2, "0")}:
-                                    {filter.startMinute.toFixed(0).padStart(2, "0")}
-                                    {" – "}
-                                    {filter.endHour.toFixed(0).padStart(2, "0")}:
-                                    {filter.endMinute.toFixed(0).padStart(2, "0")}
-                                </Typography>
-                                <Tooltip title="Fjern tidsrom">
-                                    <IconButton
-                                        onClick={(event) => {
-                                            event.preventDefault();
-                                            removeFilter(filter);
-                                        }}
-                                        sx={{ opacity: 0.5 }}
-                                    >
-                                        <DeleteRounded />
-                                    </IconButton>
-                                </Tooltip>
-                            </Stack>
+                            <>
+                                <Grid2 xs={4} textAlign={"left"} alignContent={"center"}>
+                                    <Typography>{weekdays[filter.weekday - 1]}</Typography>
+                                </Grid2>
+                                <Grid2 xs={6} sm={4} textAlign={"center"} alignContent={"center"}>
+                                    <Typography>
+                                        {filter.startHour.toFixed(0).padStart(2, "0")}:
+                                        {filter.startMinute.toFixed(0).padStart(2, "0")}
+                                        {" – "}
+                                        {filter.endHour.toFixed(0).padStart(2, "0")}:
+                                        {filter.endMinute.toFixed(0).padStart(2, "0")}
+                                    </Typography>
+                                </Grid2>
+                                <Grid2 xs={2} sm={4} textAlign={"right"} alignContent={"center"}>
+                                    <Tooltip title="Fjern tidsrom">
+                                        <IconButton
+                                            onClick={(event) => {
+                                                event.preventDefault();
+                                                removeFilter(filter);
+                                            }}
+                                            sx={{ opacity: 0.5 }}
+                                        >
+                                            <DeleteRounded />
+                                        </IconButton>
+                                    </Tooltip>
+                                </Grid2>
+                            </>
                         ))}
-                </Box>
-                {excludedClassTimeFilters.length === 0 ? (
+                </Grid2>
+                {excludeClassTimeFilters.length === 0 ? (
                     <Typography variant={"body2"} textAlign={"center"} sx={{ opacity: 0.6, fontStyle: "italic" }}>
                         Du har ikke eksludert noen tidsrom.
                     </Typography>

--- a/src/components/modals/ScheduleFiltersDialog.tsx
+++ b/src/components/modals/ScheduleFiltersDialog.tsx
@@ -50,7 +50,9 @@ export const LOCATIONS_COLOR = blue;
 
 export const CATEGORIES_COLOR = pink;
 
-export const CLASS_TIME_COLOR = purple;
+export const EXCLUDE_CLASS_TIME_COLOR = purple;
+
+const tabColors = [LOCATIONS_COLOR[500], CATEGORIES_COLOR[500], EXCLUDE_CLASS_TIME_COLOR[500]];
 
 export default function ScheduleFiltersDialog({
     open,
@@ -61,8 +63,8 @@ export default function ScheduleFiltersDialog({
     allCategories,
     selectedCategories,
     setSelectedCategories,
-    excludedClassTimeFilters,
-    setExcludedClassTimeFilters,
+    excludeClassTimeFilters,
+    setExcludeClassTimeFilters,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
@@ -72,8 +74,8 @@ export default function ScheduleFiltersDialog({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
-    excludedClassTimeFilters: ExcludeClassTimeFilter[];
-    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+    excludeClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
 }) {
     const theme = useTheme();
     const [tab, setTab] = useState(0);
@@ -90,7 +92,6 @@ export default function ScheduleFiltersDialog({
         setTab(index);
     };
 
-    const tabColors = [LOCATIONS_COLOR[500], CATEGORIES_COLOR[500], CLASS_TIME_COLOR[500]];
     const currentTabColor = tabColors[tab];
 
     return (
@@ -142,7 +143,7 @@ export default function ScheduleFiltersDialog({
                         label={"Tidsrom"}
                         icon={<AccessTimeRounded fontSize={"small"} />}
                         iconPosition={"start"}
-                        sx={{ minHeight: "3rem", color: tab == 2 ? CLASS_TIME_COLOR[500] : undefined }}
+                        sx={{ minHeight: "3rem", color: tab == 2 ? EXCLUDE_CLASS_TIME_COLOR[500] : undefined }}
                         {...a11yProps(2)}
                     />
                 </Tabs>
@@ -167,8 +168,8 @@ export default function ScheduleFiltersDialog({
                     </TabPanel>
                     <TabPanel value={tab} index={2} dir={theme.direction}>
                         <ExcludeClassTimeFilters
-                            excludedClassTimeFilters={excludedClassTimeFilters}
-                            setExcludedClassTimeFilters={setExcludedClassTimeFilters}
+                            excludeClassTimeFilters={excludeClassTimeFilters}
+                            setExcludeClassTimeFilters={setExcludeClassTimeFilters}
                         />
                     </TabPanel>
                 </SwipeableViews>

--- a/src/components/modals/ScheduleFiltersDialog.tsx
+++ b/src/components/modals/ScheduleFiltersDialog.tsx
@@ -1,6 +1,6 @@
-import { CategoryRounded, PlaceRounded } from "@mui/icons-material";
+import { AccessTimeRounded, CategoryRounded, PlaceRounded } from "@mui/icons-material";
 import { Box, Button, Dialog, Tab, Tabs, Typography, useTheme } from "@mui/material";
-import { blue, pink } from "@mui/material/colors";
+import { blue, pink, purple } from "@mui/material/colors";
 import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import { DialogHeader } from "next/dist/client/components/react-dev-overlay/internal/components/Dialog";
@@ -8,8 +8,9 @@ import React, { Dispatch, SetStateAction, useState } from "react";
 import SwipeableViews from "react-swipeable-views";
 
 import CategoryFilters from "@/components/modals/CategoryFilters";
+import ExcludeClassTimeFilters from "@/components/modals/ExcludeClassTimeFilters";
 import LocationFilters from "@/components/modals/LocationFilters";
-import { ActivityCategory, RezervoChain } from "@/types/chain";
+import { ActivityCategory, ExcludeClassTimeFilter, RezervoChain } from "@/types/chain";
 
 function a11yProps(index: number) {
     return {
@@ -49,6 +50,8 @@ export const LOCATIONS_COLOR = blue;
 
 export const CATEGORIES_COLOR = pink;
 
+export const CLASS_TIME_COLOR = purple;
+
 export default function ScheduleFiltersDialog({
     open,
     setOpen,
@@ -58,6 +61,8 @@ export default function ScheduleFiltersDialog({
     allCategories,
     selectedCategories,
     setSelectedCategories,
+    excludedClassTimeFilters,
+    setExcludedClassTimeFilters,
 }: {
     open: boolean;
     setOpen: Dispatch<SetStateAction<boolean>>;
@@ -67,6 +72,8 @@ export default function ScheduleFiltersDialog({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
+    excludedClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
 }) {
     const theme = useTheme();
     const [tab, setTab] = useState(0);
@@ -83,7 +90,8 @@ export default function ScheduleFiltersDialog({
         setTab(index);
     };
 
-    const currentTabColor = tab === 0 ? LOCATIONS_COLOR[500] : CATEGORIES_COLOR[500];
+    const tabColors = [LOCATIONS_COLOR[500], CATEGORIES_COLOR[500], CLASS_TIME_COLOR[500]];
+    const currentTabColor = tabColors[tab];
 
     return (
         <Dialog
@@ -130,6 +138,13 @@ export default function ScheduleFiltersDialog({
                         sx={{ minHeight: "3rem", color: tab == 1 ? CATEGORIES_COLOR[500] : undefined }}
                         {...a11yProps(1)}
                     />
+                    <Tab
+                        label={"Tidsrom"}
+                        icon={<AccessTimeRounded fontSize={"small"} />}
+                        iconPosition={"start"}
+                        sx={{ minHeight: "3rem", color: tab == 2 ? CLASS_TIME_COLOR[500] : undefined }}
+                        {...a11yProps(2)}
+                    />
                 </Tabs>
             </DialogHeader>
             <DialogContent sx={{ padding: 0, margin: 0 }}>
@@ -148,6 +163,12 @@ export default function ScheduleFiltersDialog({
                             allCategories={allCategories}
                             selectedCategories={selectedCategories}
                             setSelectedCategories={setSelectedCategories}
+                        />
+                    </TabPanel>
+                    <TabPanel value={tab} index={2} dir={theme.direction}>
+                        <ExcludeClassTimeFilters
+                            excludedClassTimeFilters={excludedClassTimeFilters}
+                            setExcludedClassTimeFilters={setExcludedClassTimeFilters}
                         />
                     </TabPanel>
                 </SwipeableViews>

--- a/src/components/schedule/DaySchedule.tsx
+++ b/src/components/schedule/DaySchedule.tsx
@@ -21,7 +21,7 @@ function DaySchedule({
     daySchedule,
     selectedLocationIds,
     selectedCategories,
-    excludedClassTimeFilters,
+    excludeClassTimeFilters,
     classPopularityIndex,
     selectable,
     selectedClassIds,
@@ -33,7 +33,7 @@ function DaySchedule({
     daySchedule: RezervoDaySchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
-    excludedClassTimeFilters: ExcludeClassTimeFilter[];
+    excludeClassTimeFilters: ExcludeClassTimeFilter[];
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;
@@ -49,9 +49,9 @@ function DaySchedule({
                 (c) =>
                     selectedLocationIds.includes(c.location.id) &&
                     selectedCategories.includes(c.activity.category) &&
-                    !excludedClassTimeFilters.some((filter) => isClassExcludedByTimeFilter(c, filter)),
+                    !excludeClassTimeFilters.some((filter) => isClassExcludedByTimeFilter(c, filter)),
             ),
-        [daySchedule.classes, selectedLocationIds, selectedCategories, excludedClassTimeFilters],
+        [daySchedule.classes, selectedLocationIds, selectedCategories, excludeClassTimeFilters],
     );
 
     const dayIsToday = isToday(daySchedule.date);

--- a/src/components/schedule/DaySchedule.tsx
+++ b/src/components/schedule/DaySchedule.tsx
@@ -3,10 +3,17 @@ import React, { useMemo } from "react";
 
 import ClassCard from "@/components/schedule/class/ClassCard";
 import CurrentTimeDivider from "@/components/schedule/CurrentTimeDivider";
-import { getCapitalizedWeekday, isClassInThePast, isDayPassed, isToday, LocalizedDateTime } from "@/lib/helpers/date";
+import {
+    getCapitalizedWeekday,
+    isClassInThePast,
+    isClassExcludedByTimeFilter,
+    isDayPassed,
+    isToday,
+    LocalizedDateTime,
+} from "@/lib/helpers/date";
 import { classRecurrentId } from "@/lib/helpers/recurrentId";
 import { hexWithOpacityToRgb } from "@/lib/utils/colorUtils";
-import { ChainIdentifier, RezervoClass, RezervoDaySchedule } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFilter, RezervoClass, RezervoDaySchedule } from "@/types/chain";
 import { ClassPopularity, ClassPopularityIndex } from "@/types/popularity";
 
 function DaySchedule({
@@ -14,6 +21,7 @@ function DaySchedule({
     daySchedule,
     selectedLocationIds,
     selectedCategories,
+    excludedClassTimeFilters,
     classPopularityIndex,
     selectable,
     selectedClassIds,
@@ -25,6 +33,7 @@ function DaySchedule({
     daySchedule: RezervoDaySchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
+    excludedClassTimeFilters: ExcludeClassTimeFilter[];
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;
@@ -37,9 +46,12 @@ function DaySchedule({
     const filteredClasses = useMemo(
         () =>
             daySchedule.classes.filter(
-                (c) => selectedLocationIds.includes(c.location.id) && selectedCategories.includes(c.activity.category),
+                (c) =>
+                    selectedLocationIds.includes(c.location.id) &&
+                    selectedCategories.includes(c.activity.category) &&
+                    !excludedClassTimeFilters.some((filter) => isClassExcludedByTimeFilter(c, filter)),
             ),
-        [daySchedule.classes, selectedLocationIds, selectedCategories],
+        [daySchedule.classes, selectedLocationIds, selectedCategories, excludedClassTimeFilters],
     );
 
     const dayIsToday = isToday(daySchedule.date);

--- a/src/components/schedule/WeekNavigator.tsx
+++ b/src/components/schedule/WeekNavigator.tsx
@@ -5,10 +5,14 @@ import { Avatar, Box, Button, Stack, Typography } from "@mui/material";
 import { parseAsBoolean, useQueryState } from "nuqs";
 import React, { Dispatch, SetStateAction, useMemo, useState } from "react";
 
-import ScheduleFiltersDialog, { CATEGORIES_COLOR, LOCATIONS_COLOR } from "@/components/modals/ScheduleFiltersDialog";
+import ScheduleFiltersDialog, {
+    CATEGORIES_COLOR,
+    CLASS_TIME_COLOR,
+    LOCATIONS_COLOR,
+} from "@/components/modals/ScheduleFiltersDialog";
 import { ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
 import { compactISOWeekString, fromCompactISOWeekString, LocalizedDateTime } from "@/lib/helpers/date";
-import { ActivityCategory, RezervoChain } from "@/types/chain";
+import { ActivityCategory, ExcludeClassTimeFilter, RezervoChain } from "@/types/chain";
 
 export default function WeekNavigator({
     chain,
@@ -20,6 +24,8 @@ export default function WeekNavigator({
     allCategories,
     selectedCategories,
     setSelectedCategories,
+    excludedClassTimeFilters,
+    setExcludedClassTimeFilters,
 }: {
     chain: RezervoChain;
     isLoadingPreviousWeek: boolean;
@@ -30,6 +36,8 @@ export default function WeekNavigator({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
+    excludedClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
 }) {
     const [weekParam, setWeekParam] = useQueryState(ISO_WEEK_QUERY_PARAM);
     const [scrollToNowParam, setScrollToNowParam] = useQueryState(SCROLL_TO_NOW_QUERY_PARAM, parseAsBoolean);
@@ -43,7 +51,11 @@ export default function WeekNavigator({
         return selectedCategories.length < allCategories.length;
     }, [selectedCategories, allCategories]);
 
-    const isFiltered = isLocationFiltered || isCategoryFiltered;
+    const isClassTimeFiltered = useMemo(() => {
+        return excludedClassTimeFilters.length > 0;
+    }, [excludedClassTimeFilters]);
+
+    const isFiltered = isLocationFiltered || isCategoryFiltered || isClassTimeFiltered;
 
     const [isScheduleFiltersOpen, setIsScheduleFiltersOpen] = useState(false);
 
@@ -118,6 +130,18 @@ export default function WeekNavigator({
                                 {selectedCategories.length}
                             </Avatar>
                         )}
+                        {isClassTimeFiltered && (
+                            <Avatar
+                                sx={{
+                                    width: 20,
+                                    height: 20,
+                                    fontSize: 12,
+                                    backgroundColor: CLASS_TIME_COLOR[500],
+                                }}
+                            >
+                                {excludedClassTimeFilters.length}
+                            </Avatar>
+                        )}
                     </Box>
                 )}
             </Button>
@@ -130,6 +154,8 @@ export default function WeekNavigator({
                 allCategories={allCategories}
                 selectedCategories={selectedCategories}
                 setSelectedCategories={setSelectedCategories}
+                excludedClassTimeFilters={excludedClassTimeFilters}
+                setExcludedClassTimeFilters={setExcludedClassTimeFilters}
             />
             <LoadingButton
                 loading={isLoadingPreviousWeek}

--- a/src/components/schedule/WeekNavigator.tsx
+++ b/src/components/schedule/WeekNavigator.tsx
@@ -7,7 +7,7 @@ import React, { Dispatch, SetStateAction, useMemo, useState } from "react";
 
 import ScheduleFiltersDialog, {
     CATEGORIES_COLOR,
-    CLASS_TIME_COLOR,
+    EXCLUDE_CLASS_TIME_COLOR,
     LOCATIONS_COLOR,
 } from "@/components/modals/ScheduleFiltersDialog";
 import { ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
@@ -136,7 +136,7 @@ export default function WeekNavigator({
                                     width: 20,
                                     height: 20,
                                     fontSize: 12,
-                                    backgroundColor: CLASS_TIME_COLOR[500],
+                                    backgroundColor: EXCLUDE_CLASS_TIME_COLOR[500],
                                 }}
                             >
                                 {excludedClassTimeFilters.length}

--- a/src/components/schedule/WeekNavigator.tsx
+++ b/src/components/schedule/WeekNavigator.tsx
@@ -24,8 +24,8 @@ export default function WeekNavigator({
     allCategories,
     selectedCategories,
     setSelectedCategories,
-    excludedClassTimeFilters,
-    setExcludedClassTimeFilters,
+    excludeClassTimeFilters,
+    setExcludeClassTimeFilters,
 }: {
     chain: RezervoChain;
     isLoadingPreviousWeek: boolean;
@@ -36,8 +36,8 @@ export default function WeekNavigator({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
-    excludedClassTimeFilters: ExcludeClassTimeFilter[];
-    setExcludedClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+    excludeClassTimeFilters: ExcludeClassTimeFilter[];
+    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
 }) {
     const [weekParam, setWeekParam] = useQueryState(ISO_WEEK_QUERY_PARAM);
     const [scrollToNowParam, setScrollToNowParam] = useQueryState(SCROLL_TO_NOW_QUERY_PARAM, parseAsBoolean);
@@ -52,8 +52,8 @@ export default function WeekNavigator({
     }, [selectedCategories, allCategories]);
 
     const isClassTimeFiltered = useMemo(() => {
-        return excludedClassTimeFilters.length > 0;
-    }, [excludedClassTimeFilters]);
+        return excludeClassTimeFilters.length > 0;
+    }, [excludeClassTimeFilters]);
 
     const isFiltered = isLocationFiltered || isCategoryFiltered || isClassTimeFiltered;
 
@@ -139,7 +139,7 @@ export default function WeekNavigator({
                                     backgroundColor: EXCLUDE_CLASS_TIME_COLOR[500],
                                 }}
                             >
-                                {excludedClassTimeFilters.length}
+                                {excludeClassTimeFilters.length}
                             </Avatar>
                         )}
                     </Box>
@@ -154,8 +154,8 @@ export default function WeekNavigator({
                 allCategories={allCategories}
                 selectedCategories={selectedCategories}
                 setSelectedCategories={setSelectedCategories}
-                excludedClassTimeFilters={excludedClassTimeFilters}
-                setExcludedClassTimeFilters={setExcludedClassTimeFilters}
+                excludeClassTimeFilters={excludeClassTimeFilters}
+                setExcludeClassTimeFilters={setExcludeClassTimeFilters}
             />
             <LoadingButton
                 loading={isLoadingPreviousWeek}

--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -11,7 +11,7 @@ function WeekSchedule({
     weekSchedule,
     selectedLocationIds,
     selectedCategories,
-    excludedClassTimeFilters,
+    excludeClassTimeFilters,
     classPopularityIndex,
     selectable,
     selectedClassIds,
@@ -23,7 +23,7 @@ function WeekSchedule({
     weekSchedule: RezervoWeekSchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
-    excludedClassTimeFilters: ExcludeClassTimeFilter[];
+    excludeClassTimeFilters: ExcludeClassTimeFilter[];
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;
@@ -59,7 +59,7 @@ function WeekSchedule({
                                     daySchedule={daySchedule}
                                     selectedLocationIds={selectedLocationIds}
                                     selectedCategories={selectedCategories}
-                                    excludedClassTimeFilters={excludedClassTimeFilters}
+                                    excludeClassTimeFilters={excludeClassTimeFilters}
                                     classPopularityIndex={classPopularityIndex}
                                     selectable={selectable}
                                     selectedClassIds={selectedClassIds}

--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import DaySchedule from "@/components/schedule/DaySchedule";
 import { isToday } from "@/lib/helpers/date";
-import { ChainIdentifier, RezervoClass, RezervoWeekSchedule } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFilter, RezervoClass, RezervoWeekSchedule } from "@/types/chain";
 import { ClassPopularityIndex } from "@/types/popularity";
 
 function WeekSchedule({
@@ -11,6 +11,7 @@ function WeekSchedule({
     weekSchedule,
     selectedLocationIds,
     selectedCategories,
+    excludedClassTimeFilters,
     classPopularityIndex,
     selectable,
     selectedClassIds,
@@ -22,6 +23,7 @@ function WeekSchedule({
     weekSchedule: RezervoWeekSchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
+    excludedClassTimeFilters: ExcludeClassTimeFilter[];
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;
@@ -57,6 +59,7 @@ function WeekSchedule({
                                     daySchedule={daySchedule}
                                     selectedLocationIds={selectedLocationIds}
                                     selectedCategories={selectedCategories}
+                                    excludedClassTimeFilters={excludedClassTimeFilters}
                                     classPopularityIndex={classPopularityIndex}
                                     selectable={selectable}
                                     selectedClassIds={selectedClassIds}

--- a/src/lib/helpers/storage.ts
+++ b/src/lib/helpers/storage.ts
@@ -7,7 +7,7 @@ const STORAGE_KEYS = {
     SELECTED_CHAIN: `${STORAGE_KEY_PREFIX}selectedChain`,
     selectedLocations: (chain: string) => `${STORAGE_KEY_PREFIX}selectedLocations.${chain}`,
     selectedCategories: (chain: string) => `${STORAGE_KEY_PREFIX}selectedCategories.${chain}`,
-    excludedClassTimeFilters: `${STORAGE_KEY_PREFIX}excludedClassTimeFilters`,
+    excludeClassTimeFilters: `${STORAGE_KEY_PREFIX}excludeClassTimeFilters`,
 };
 
 function storeValue<T>(key: string, value: T) {
@@ -39,12 +39,12 @@ export function getStoredSelectedCategories(chainIdentifier: string): string[] |
     return getStoredValue<string[]>(STORAGE_KEYS.selectedCategories(chainIdentifier), true);
 }
 
-export function storeExcludedClassTimeFilters(excludedClassTimeFilters: ExcludeClassTimeFilter[]) {
-    storeValue(STORAGE_KEYS.excludedClassTimeFilters, excludedClassTimeFilters);
+export function storeExcludeClassTimeFilters(excludeClassTimeFilters: ExcludeClassTimeFilter[]) {
+    storeValue(STORAGE_KEYS.excludeClassTimeFilters, excludeClassTimeFilters);
 }
 
-export function getStoredExcludedClassTimeFilters(): ExcludeClassTimeFilter[] | null {
-    return getStoredValue<ExcludeClassTimeFilter[]>(STORAGE_KEYS.excludedClassTimeFilters, true);
+export function getStoredExcludeClassTimeFilters(): ExcludeClassTimeFilter[] | null {
+    return getStoredValue<ExcludeClassTimeFilter[]>(STORAGE_KEYS.excludeClassTimeFilters, true);
 }
 
 function storeAsCookie<T>(key: string, value: T) {

--- a/src/lib/helpers/storage.ts
+++ b/src/lib/helpers/storage.ts
@@ -1,12 +1,13 @@
 import Cookies from "js-cookie";
 
-import { ChainIdentifier } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFilter } from "@/types/chain";
 
 const STORAGE_KEY_PREFIX = "rezervo.";
 const STORAGE_KEYS = {
     SELECTED_CHAIN: `${STORAGE_KEY_PREFIX}selectedChain`,
     selectedLocations: (chain: string) => `${STORAGE_KEY_PREFIX}selectedLocations.${chain}`,
     selectedCategories: (chain: string) => `${STORAGE_KEY_PREFIX}selectedCategories.${chain}`,
+    excludedClassTimeFilters: `${STORAGE_KEY_PREFIX}excludedClassTimeFilters`,
 };
 
 function storeValue<T>(key: string, value: T) {
@@ -36,6 +37,14 @@ export function storeSelectedCategories(chainIdentifier: string, categories: str
 
 export function getStoredSelectedCategories(chainIdentifier: string): string[] | null {
     return getStoredValue<string[]>(STORAGE_KEYS.selectedCategories(chainIdentifier), true);
+}
+
+export function storeExcludedClassTimeFilters(excludedClassTimeFilters: ExcludeClassTimeFilter[]) {
+    storeValue(STORAGE_KEYS.excludedClassTimeFilters, excludedClassTimeFilters);
+}
+
+export function getStoredExcludedClassTimeFilters(): ExcludeClassTimeFilter[] | null {
+    return getStoredValue<ExcludeClassTimeFilter[]>(STORAGE_KEYS.excludedClassTimeFilters, true);
 }
 
 function storeAsCookie<T>(key: string, value: T) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,7 +22,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         <CssVarsProvider theme={theme} defaultMode={"system"}>
             <CssBaseline enableColorScheme />
             <UserProvider>
-                <LocalizationProvider dateAdapter={AdapterLuxon}>
+                <LocalizationProvider dateAdapter={AdapterLuxon} adapterLocale="nb-NO">
                     {showSnow && (
                         <Snowfall
                             speed={[0.5, 1.0]}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -4,6 +4,8 @@ import "@/components/schedule/class/ClassCard.css";
 
 import { UserProvider } from "@auth0/nextjs-auth0/client";
 import { CssBaseline, Experimental_CssVarsProvider as CssVarsProvider } from "@mui/material";
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon";
 import type { AppProps } from "next/app";
 import React, { useEffect, useState } from "react";
 import Snowfall from "react-snowfall";
@@ -20,19 +22,21 @@ function MyApp({ Component, pageProps }: AppProps) {
         <CssVarsProvider theme={theme} defaultMode={"system"}>
             <CssBaseline enableColorScheme />
             <UserProvider>
-                {showSnow && (
-                    <Snowfall
-                        speed={[0.5, 1.0]}
-                        wind={[0, 0.5]}
-                        style={{
-                            zIndex: 2412,
-                            position: "fixed",
-                            width: "100vw",
-                            height: "100vh",
-                        }}
-                    />
-                )}
-                <Component {...pageProps} />
+                <LocalizationProvider dateAdapter={AdapterLuxon}>
+                    {showSnow && (
+                        <Snowfall
+                            speed={[0.5, 1.0]}
+                            wind={[0, 0.5]}
+                            style={{
+                                zIndex: 2412,
+                                position: "fixed",
+                                width: "100vw",
+                                height: "100vh",
+                            }}
+                        />
+                    )}
+                    <Component {...pageProps} />
+                </LocalizationProvider>
             </UserProvider>
         </CssVarsProvider>
     );

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -105,3 +105,11 @@ export type BookingPopupState = {
     _class: RezervoClass;
     action: BookingPopupAction;
 };
+
+export type ExcludeClassTimeFilter = {
+    weekday: number;
+    startHour: number;
+    startMinute: number;
+    endHour: number;
+    endMinute: number;
+};

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -1,4 +1,4 @@
-import { DateTime } from "luxon";
+import { DateTime, HourNumbers, MinuteNumbers, WeekdayNumbers } from "luxon";
 
 export type ChainIdentifier = string;
 
@@ -107,9 +107,9 @@ export type BookingPopupState = {
 };
 
 export type ExcludeClassTimeFilter = {
-    weekday: number;
-    startHour: number;
-    startMinute: number;
-    endHour: number;
-    endMinute: number;
+    weekday: WeekdayNumbers;
+    startHour: HourNumbers;
+    startMinute: MinuteNumbers;
+    endHour: HourNumbers;
+    endMinute: MinuteNumbers;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,6 +83,13 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.25.6":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.6.tgz#9afc3289f7184d8d7f98b099884c26317b9264d2"
+  integrity sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
 "@babel/types@^7.21.4":
   version "7.21.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
@@ -556,6 +563,11 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.14.tgz#8a02ac129b70f3d82f2f9b76ded2c8d48e3fc8c9"
   integrity sha512-MZsBZ4q4HfzBsywtXgM1Ksj6HDThtiwmOKUXH1pKYISI9gAVXCNHNpo7TlGoGrBaYWZTdNoirIN7JsQcQUjmQQ==
 
+"@mui/types@^7.2.15":
+  version "7.2.17"
+  resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.2.17.tgz#329826062d4079de5ea2b97007575cebbba1fdbc"
+  integrity sha512-oyumoJgB6jDV8JFzRqjBo2daUuHpzDjoO/e3IrRhhHo/FxJlaVhET6mcNrKHUq2E+R+q3ql0qAtvQ4rfWHhAeQ==
+
 "@mui/utils@^5.15.14":
   version "5.15.14"
   resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.15.14.tgz#e414d7efd5db00bfdc875273a40c0a89112ade3a"
@@ -565,6 +577,39 @@
     "@types/prop-types" "^15.7.11"
     prop-types "^15.8.1"
     react-is "^18.2.0"
+
+"@mui/utils@^5.16.6":
+  version "5.16.6"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.16.6.tgz#905875bbc58d3dcc24531c3314a6807aba22a711"
+  integrity sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==
+  dependencies:
+    "@babel/runtime" "^7.23.9"
+    "@mui/types" "^7.2.15"
+    "@types/prop-types" "^15.7.12"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-is "^18.3.1"
+
+"@mui/x-date-pickers@^7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-date-pickers/-/x-date-pickers-7.18.0.tgz#264158195aeeaf32a00519718f6c67c165b06711"
+  integrity sha512-12tXIoMj9vpS8fS/bS3kWPCoVrH38vNGCxgplI0vOnUrN9rJuYJz3agLPJe1S0xciTw+9W8ZSe3soaW+owoz1Q==
+  dependencies:
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
+    "@mui/x-internals" "7.18.0"
+    "@types/react-transition-group" "^4.4.11"
+    clsx "^2.1.1"
+    prop-types "^15.8.1"
+    react-transition-group "^4.4.5"
+
+"@mui/x-internals@7.18.0":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-internals/-/x-internals-7.18.0.tgz#f079968d4f7ea93e63be9faf6ba8558d6f12923b"
+  integrity sha512-lzCHOWIR0cAIY1bGrWSprYerahbnH5C31ql/2OWCEjcngL2NAV1M6oKI2Vp4HheqzJ822c60UyWyapvyjSzY/A==
+  dependencies:
+    "@babel/runtime" "^7.25.6"
+    "@mui/utils" "^5.16.6"
 
 "@next/env@14.2.2":
   version "14.2.2"
@@ -884,6 +929,11 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
+"@types/prop-types@^15.7.12":
+  version "15.7.13"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
+  integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
+
 "@types/react-dom@^18.2.25":
   version "18.2.25"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.25.tgz#2946a30081f53e7c8d585eb138277245caedc521"
@@ -902,6 +952,13 @@
   version "4.4.10"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.10.tgz#6ee71127bdab1f18f11ad8fb3322c6da27c327ac"
   integrity sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.11":
+  version "4.4.11"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.11.tgz#d963253a611d757de01ebb241143b1017d5d63d5"
+  integrity sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==
   dependencies:
     "@types/react" "*"
 
@@ -1465,6 +1522,11 @@ clsx@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
   integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
+
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -3656,6 +3718,11 @@ react-is@^18.2.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-is@^18.3.1:
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
 react-snowfall@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-snowfall/-/react-snowfall-1.2.1.tgz#68cab6a1d05aa7c3211bce96a3a97977ca7dc57f"
@@ -4083,16 +4150,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -4187,14 +4245,7 @@ string.prototype.trimstart@^1.0.7:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Users can add any number of time periods to exclude from their schedules, selecting a weekday, starting and ending times for each. There is validation for the inputs, ensuring that only valid, non-duplicate entries are added. :unicorn: 

See attached screenshots:

![2024-09-20_23-45](https://github.com/user-attachments/assets/43cbc117-3cf6-4944-8f83-8058f52a916d)
![2024-09-20_23-40](https://github.com/user-attachments/assets/31cb6d6a-a021-4c05-a2ce-124571e7fe60)
![2024-09-20_23-41](https://github.com/user-attachments/assets/f60153d1-c361-445e-a7ee-0a1b8a6c8856)
![2024-09-20_23-42](https://github.com/user-attachments/assets/babe85b9-4a5a-4706-b177-c721b60276be)
![2024-09-20_23-42_1](https://github.com/user-attachments/assets/aaf0514c-db67-44a6-9e16-ba75e7bc6f5c)
![2024-09-20_23-44_1](https://github.com/user-attachments/assets/174420fc-16df-415f-8752-cf4fa01d4b8a)
![2024-09-20_23-43](https://github.com/user-attachments/assets/9b650936-c4a5-4092-97d0-481c57f3676a)
![2024-09-20_23-44](https://github.com/user-attachments/assets/fc37e07d-2a4b-41c7-81b8-3707d29fb428)
