### PR TITLE
Extract Common Modal Components To Reduce Duplication

### DIFF
--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -11,6 +11,7 @@ import React from "react";
 
 import AgendaEntry from "@/components/modals/Agenda/AgendaSession";
 import ModalWrapper from "@/components/modals/ModalWrapper";
+import SubHeader from "@/components/modals/SubHeader";
 import { PLANNED_SESSIONS_NEXT_WHOLE_WEEKS } from "@/lib/consts";
 import { capitalizeFirstCharacter, isClassInThePast } from "@/lib/helpers/date";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
@@ -147,9 +148,7 @@ export default function Agenda({
                                 {PLANNED_SESSIONS_NEXT_WHOLE_WEEKS} ukene. Kontroller at planen din stemmer overens med
                                 treningssenteret sin timeplan.
                             </Alert>
-                            <Typography variant="h6" sx={{ fontSize: 18 }}>
-                                Utdaterte timer
-                            </Typography>
+                            <SubHeader title={"Utdaterte timer"} />
                             {Object.entries(missingClassConfigs).flatMap(([chain, classConfigs]) =>
                                 classConfigs.map((classConfig) => (
                                     <AgendaEntry
@@ -161,31 +160,14 @@ export default function Agenda({
                             )}
                         </Box>
                     )}
-                    <Box>
-                        <Typography variant="h6" sx={{ fontSize: 18 }}>
-                            Mine bookinger
-                        </Typography>
-                        {Object.keys(bookedSessionsDayMap).length === 0 && (
-                            <Typography variant={"body2"} sx={{ opacity: 0.6, fontStyle: "italic" }}>
-                                Du har ingen bookinger
-                            </Typography>
-                        )}
-                    </Box>
+                    <SubHeader
+                        title={"Mine bookinger"}
+                        placeholder={"Du har ingen bookinger"}
+                        showPlaceholder={Object.keys(bookedSessionsDayMap).length === 0}
+                    />
                     <AgendaDays dayMap={bookedSessionsDayMap} />
-                    <Box>
-                        <Typography variant="h6" sx={{ fontSize: 18, pt: 2 }}>
-                            Planlagte timer
-                        </Typography>
-                        <Typography
-                            variant="body2"
-                            style={{
-                                color: theme.palette.grey[600],
-                                fontSize: 15,
-                            }}
-                        >
-                            Disse timene vil bli booket automatisk
-                        </Typography>
-                    </Box>
+                    <Box height={2} />
+                    <SubHeader title={"Planlagte timer"} description={"Disse timene vil bli booket automatisk"} />
                     {inactiveChains.length > 0 &&
                         (inactiveChains.length === Object.keys(chainConfigs).length ? (
                             <Alert severity={"info"} icon={<PauseCircleRounded />}>

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -10,6 +10,7 @@ import { Alert, AlertTitle, Avatar, Box, Stack, Typography, useTheme } from "@mu
 import React from "react";
 
 import AgendaEntry from "@/components/modals/Agenda/AgendaSession";
+import ModalWrapper from "@/components/modals/ModalWrapper";
 import { PLANNED_SESSIONS_NEXT_WHOLE_WEEKS } from "@/lib/consts";
 import { capitalizeFirstCharacter, isClassInThePast } from "@/lib/helpers/date";
 import { classConfigRecurrentId, classRecurrentId } from "@/lib/helpers/recurrentId";
@@ -111,40 +112,7 @@ export default function Agenda({
     const inactiveChains = Object.keys(chainConfigs).filter((chain) => !chainConfigs[chain]?.active);
 
     return (
-        <Box
-            sx={{
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                width: "95%",
-                maxHeight: "80%",
-                overflowY: "auto",
-                maxWidth: 500,
-                minHeight: 300,
-                transform: "translate(-50%, -50%)",
-                borderRadius: "0.25em",
-                boxShadow: 24,
-                p: 4,
-                backgroundColor: "white",
-                '[data-mui-color-scheme="dark"] &': {
-                    backgroundColor: "#181818",
-                },
-            }}
-        >
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 1,
-                    paddingBottom: 2,
-                }}
-            >
-                {userSessions.length > 0 ? <CalendarMonth /> : <CalendarToday />}
-                <Typography variant="h6" component="h2">
-                    Min timeplan
-                </Typography>
-            </Box>
+        <ModalWrapper title={"Agenda"} icon={userSessions.length > 0 ? <CalendarMonth /> : <CalendarToday />}>
             {Object.keys(chainConfigs).length === 0 ? (
                 <Alert severity="info" sx={{ mt: 1.5 }}>
                     <AlertTitle>Mangler medlemskap</AlertTitle>
@@ -276,6 +244,6 @@ export default function Agenda({
                     </Stack>
                 </Box>
             )}
-        </Box>
+        </ModalWrapper>
     );
 }

--- a/src/components/modals/Agenda/Agenda.tsx
+++ b/src/components/modals/Agenda/Agenda.tsx
@@ -113,7 +113,7 @@ export default function Agenda({
     const inactiveChains = Object.keys(chainConfigs).filter((chain) => !chainConfigs[chain]?.active);
 
     return (
-        <ModalWrapper title={"Agenda"} icon={userSessions.length > 0 ? <CalendarMonth /> : <CalendarToday />}>
+        <ModalWrapper title={"Min timeplan"} icon={userSessions.length > 0 ? <CalendarMonth /> : <CalendarToday />}>
             {Object.keys(chainConfigs).length === 0 ? (
                 <Alert severity="info" sx={{ mt: 1.5 }}>
                     <AlertTitle>Mangler medlemskap</AlertTitle>

--- a/src/components/modals/ClassInfo/ClassInfo.tsx
+++ b/src/components/modals/ClassInfo/ClassInfo.tsx
@@ -15,13 +15,14 @@ import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
 import LocationOnRoundedIcon from "@mui/icons-material/LocationOnRounded";
 import PersonRoundedIcon from "@mui/icons-material/PersonRounded";
 import LoadingButton from "@mui/lab/LoadingButton";
-import { Alert, AlertTitle, Box, Stack, Typography } from "@mui/material";
+import { Alert, AlertTitle, Box, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import Image from "next/image";
 import React, { useState } from "react";
 
 import ClassInfoEntry from "@/components/modals/ClassInfo/ClassInfoEntry";
 import ClassInfoUsersGroup from "@/components/modals/ClassInfo/ClassInfoUsersGroup";
+import ModalWrapper from "@/components/modals/ModalWrapper";
 import ClassPopularityMeter from "@/components/schedule/class/ClassPopularityMeter";
 import ConfirmCancellation from "@/components/schedule/class/ConfirmCancellation";
 import { NoShowBadgeIcon } from "@/components/utils/NoShowBadgeIcon";
@@ -98,33 +99,9 @@ export default function ClassInfo({
     const positionedUsersInWaitList = usersOnWaitlist.filter((u) => u.positionInWaitList);
 
     return (
-        <Box
-            sx={{
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                width: "95%",
-                maxHeight: "80%",
-                overflowY: "auto",
-                maxWidth: 600,
-                transform: "translate(-50%, -50%)",
-                borderRadius: "0.25em",
-                boxShadow: 24,
-                p: 4,
-                backgroundColor: "white",
-                '[data-mui-color-scheme="dark"] &': {
-                    backgroundColor: "#181818",
-                },
-            }}
-        >
-            <Stack
-                direction={"row"}
-                sx={{
-                    gap: 1,
-                    alignItems: "center",
-                    paddingBottom: 1,
-                }}
-            >
+        <ModalWrapper
+            title={_class.activity.name}
+            icon={
                 <Box
                     sx={{
                         borderRadius: "50%",
@@ -136,10 +113,9 @@ export default function ClassInfo({
                         },
                     }}
                 />
-                <Typography variant="h6" component="h2">
-                    {_class.activity.name}
-                </Typography>
-            </Stack>
+            }
+            titleAlignment={"left"}
+        >
             {_class.isCancelled && (
                 <Alert severity={"error"} icon={<CancelRounded />}>
                     {_class.cancelText ? (
@@ -372,6 +348,6 @@ export default function ClassInfo({
                 chain={chain}
                 _class={_class}
             />
-        </Box>
+        </ModalWrapper>
     );
 }

--- a/src/components/modals/Community/Community.tsx
+++ b/src/components/modals/Community/Community.tsx
@@ -1,8 +1,9 @@
 import { People } from "@mui/icons-material";
-import { Alert, Badge, Box, Divider, Tooltip, Typography, useTheme } from "@mui/material";
+import { Alert, Badge, Box, Divider, Tooltip, Typography } from "@mui/material";
 import React, { ReactNode } from "react";
 
 import CommunityUserCard from "@/components/modals/Community/CommunityUserCard";
+import ModalWrapper from "@/components/modals/ModalWrapper";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { ChainProfile } from "@/types/chain";
 import { CommunityUser, UserRelationship } from "@/types/community";
@@ -43,7 +44,6 @@ const CommunityUserList = ({
 
 const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
     const { community, communityLoading, communityError } = useCommunity();
-    const theme = useTheme();
 
     const friendRequests =
         community?.users.filter((user) => user.relationship === UserRelationship.REQUEST_RECEIVED) ?? [];
@@ -66,60 +66,11 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
     };
 
     return (
-        <Box
-            sx={{
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                width: "90%",
-                maxHeight: "80%",
-                overflowY: "auto",
-                maxWidth: 520,
-                transform: "translate(-50%, -50%)",
-                borderRadius: "0.25em",
-                boxShadow: 24,
-                p: 4,
-                backgroundColor: "white",
-                '[data-mui-color-scheme="dark"] &': {
-                    backgroundColor: "#111",
-                },
-            }}
+        <ModalWrapper
+            title={"Venner"}
+            icon={<People />}
+            description={"Venner kan se hverandres bookinger og timeplaner"}
         >
-            <Box
-                sx={{
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: 1,
-                    paddingBottom: 1,
-                }}
-            >
-                <Box
-                    sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 1,
-                    }}
-                >
-                    <People />
-                    <Typography variant="h6" component="h2">
-                        Venner
-                    </Typography>
-                </Box>
-                <Typography
-                    variant="body2"
-                    style={{
-                        color: theme.palette.grey[600],
-                        fontSize: 15,
-                    }}
-                    sx={{
-                        textAlign: "center",
-                        mb: 2.5,
-                    }}
-                >
-                    Venner kan se hverandres bookinger og timeplaner
-                </Typography>
-            </Box>
             {communityError ? (
                 <Alert severity="error">
                     <Typography>Klarte ikke laste inn venner.</Typography>
@@ -155,7 +106,7 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                     )}
                 </Box>
             )}
-        </Box>
+        </ModalWrapper>
     );
 };
 

--- a/src/components/modals/Community/Community.tsx
+++ b/src/components/modals/Community/Community.tsx
@@ -4,36 +4,32 @@ import React, { ReactNode } from "react";
 
 import CommunityUserCard from "@/components/modals/Community/CommunityUserCard";
 import ModalWrapper from "@/components/modals/ModalWrapper";
+import SubHeader from "@/components/modals/SubHeader";
 import { useCommunity } from "@/lib/hooks/useCommunity";
 import { ChainProfile } from "@/types/chain";
 import { CommunityUser, UserRelationship } from "@/types/community";
 
 const CommunityUserList = ({
     title,
-    defaultText,
+    placeholder,
     communityUsers,
     chainProfiles,
     badge,
 }: {
     title: string;
-    defaultText: string;
+    placeholder: string;
     communityUsers: CommunityUser[];
     chainProfiles: ChainProfile[];
     badge?: ReactNode;
 }) => {
     return (
         <Box>
-            <Box sx={{ display: "flex", alignItems: "center" }}>
-                <Typography variant="h6" sx={{ fontSize: 18 }}>
-                    {title}
-                </Typography>
-                {badge}
-            </Box>
-            {communityUsers.length === 0 && (
-                <Typography variant={"body2"} sx={{ opacity: 0.6, fontStyle: "italic" }}>
-                    {defaultText}
-                </Typography>
-            )}
+            <SubHeader
+                title={title}
+                endIcon={badge}
+                placeholder={placeholder}
+                showPlaceholder={communityUsers.length === 0}
+            />
             {communityUsers.length > 0 && <Divider sx={{ mt: 1 }} />}
             {communityUsers.map((cu) => (
                 <CommunityUserCard key={cu.name} communityUser={cu} chainProfiles={chainProfiles} />
@@ -51,13 +47,13 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
         return (
             <CommunityUserList
                 title={"Venneforespørsler"}
-                defaultText={"Du har ingen ubesvarte venneforespørsler"}
+                placeholder={"Du har ingen ubesvarte venneforespørsler"}
                 communityUsers={friendRequests}
                 chainProfiles={chainProfiles}
                 badge={
                     friendRequests.length > 0 && (
                         <Tooltip title={`Du har ${friendRequests.length} ubesvarte venneforespørsler`}>
-                            <Badge sx={{ ml: 2 }} badgeContent={friendRequests.length} color={"error"} />
+                            <Badge sx={{ ml: 0.3 }} badgeContent={friendRequests.length} color={"error"} />
                         </Tooltip>
                     )
                 }
@@ -82,7 +78,7 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                             {friendRequests.length > 0 && <FriendRequests />}
                             <CommunityUserList
                                 title={"Dine venner"}
-                                defaultText={"Du har ingen venner"}
+                                placeholder={"Du har ingen venner"}
                                 communityUsers={
                                     community?.users.filter((user) => user.relationship === UserRelationship.FRIEND) ??
                                     []
@@ -91,7 +87,7 @@ const Community = ({ chainProfiles }: { chainProfiles: ChainProfile[] }) => {
                             />
                             <CommunityUserList
                                 title={"Personer du kanskje kjenner"}
-                                defaultText={"Du har ingen venneforslag"}
+                                placeholder={"Du har ingen venneforslag"}
                                 communityUsers={
                                     community?.users.filter(
                                         (user) =>

--- a/src/components/modals/ModalWrapper.tsx
+++ b/src/components/modals/ModalWrapper.tsx
@@ -1,0 +1,80 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import React, { ReactNode } from "react";
+
+export default function ModalWrapper({
+    children,
+    title,
+    icon,
+    titleAlignment = "center",
+    description,
+}: {
+    children: ReactNode;
+    title: string;
+    icon: ReactNode;
+    titleAlignment?: "left" | "center";
+    description?: string;
+}) {
+    const theme = useTheme();
+
+    return (
+        <Box
+            sx={{
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                width: "90%",
+                maxHeight: "80%",
+                overflowY: "auto",
+                maxWidth: 550,
+                minHeight: 300,
+                transform: "translate(-50%, -50%)",
+                borderRadius: "0.25em",
+                boxShadow: 24,
+                p: 4,
+                backgroundColor: "white",
+                '[data-mui-color-scheme="dark"] &': {
+                    backgroundColor: "#111",
+                },
+            }}
+        >
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: titleAlignment,
+                    gap: 1,
+                    paddingBottom: 1,
+                }}
+            >
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 1,
+                    }}
+                >
+                    {icon}
+                    <Typography variant="h6" component="h2">
+                        {title}
+                    </Typography>
+                </Box>
+                {description && (
+                    <Typography
+                        variant="body2"
+                        style={{
+                            color: theme.palette.grey[600],
+                            fontSize: 15,
+                        }}
+                        sx={{
+                            textAlign: "center",
+                            mb: 2.5,
+                        }}
+                    >
+                        {description}
+                    </Typography>
+                )}
+            </Box>
+            {children}
+        </Box>
+    );
+}

--- a/src/components/modals/Profile/Profile.tsx
+++ b/src/components/modals/Profile/Profile.tsx
@@ -5,6 +5,7 @@ import Button from "@mui/material/Button";
 import React, { useState } from "react";
 import Dropzone from "react-dropzone";
 
+import ModalWrapper from "@/components/modals/ModalWrapper";
 import AvatarMutateAlert from "@/components/modals/Profile/AvatarMutateAlert";
 import EditAvatarDialog from "@/components/modals/Profile/EditAvatarDialog";
 import ProfileAvatar from "@/components/modals/Profile/ProfileAvatar";
@@ -135,41 +136,7 @@ function Profile({
             }}
         >
             {({ getRootProps: getDialogRootProps }) => (
-                <Box
-                    {...getDialogRootProps()}
-                    sx={{
-                        position: "absolute",
-                        top: "50%",
-                        left: "50%",
-                        width: "90%",
-                        maxHeight: "80%",
-                        overflowY: "auto",
-                        maxWidth: 420,
-                        minHeight: 300,
-                        transform: "translate(-50%, -50%)",
-                        borderRadius: "0.25em",
-                        boxShadow: 24,
-                        p: 4,
-                        backgroundColor: "white",
-                        '[data-mui-color-scheme="dark"] &': {
-                            backgroundColor: "#111",
-                        },
-                    }}
-                >
-                    <Box
-                        sx={{
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            gap: 1,
-                            paddingBottom: 2,
-                        }}
-                    >
-                        <PersonRounded />
-                        <Typography variant="h6" component="h2">
-                            Profil
-                        </Typography>
-                    </Box>
+                <ModalWrapper {...getDialogRootProps()} title={"Profil"} icon={<PersonRounded />}>
                     <AvatarMutateAlert
                         visible={showAvatarMutateError}
                         error={avatarMutateError}
@@ -309,7 +276,7 @@ function Profile({
                             deleteAvatar();
                         }}
                     />
-                </Box>
+                </ModalWrapper>
             )}
         </Dropzone>
     );

--- a/src/components/modals/Settings/CalendarFeed.tsx
+++ b/src/components/modals/Settings/CalendarFeed.tsx
@@ -1,13 +1,14 @@
 import { Check } from "@mui/icons-material";
 import CalendarMonthRoundedIcon from "@mui/icons-material/CalendarMonthRounded";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-import { Box, Checkbox, FormControlLabel, FormGroup, FormLabel, Typography, useTheme } from "@mui/material";
+import { Box, Checkbox, FormControlLabel, FormGroup, FormLabel } from "@mui/material";
 import IconButton from "@mui/material/IconButton";
 import InputAdornment from "@mui/material/InputAdornment";
 import TextField from "@mui/material/TextField";
 import Tooltip from "@mui/material/Tooltip";
 import React, { useState } from "react";
 
+import SubHeader from "@/components/modals/SubHeader";
 import { useCopyToClipboard } from "@/lib/hooks/useCopyToClipboard";
 import { useUserCalendarFeedUrl } from "@/lib/hooks/useUserCalendarFeedUrl";
 
@@ -20,7 +21,6 @@ export default function CalendarFeed() {
     const [isCopiedToClipboard, isSupported, copyToClipboard] = useCopyToClipboard(userCalendarFeedUrl || "", {
         successDuration: 3000,
     });
-    const theme = useTheme();
 
     return (
         <Box
@@ -31,25 +31,13 @@ export default function CalendarFeed() {
                 gap: "1rem",
             }}
         >
-            <Box>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pb: 1 }}>
-                    <CalendarMonthRoundedIcon fontSize={"small"} />
-                    <Typography variant="h6" sx={{ fontSize: 18 }}>
-                        Kalender
-                    </Typography>
-                </Box>
-                <Typography
-                    variant="body2"
-                    sx={{
-                        color: theme.palette.grey[600],
-                        fontSize: 14,
-                        mb: 1,
-                    }}
-                >
-                    Kopier denne lenken inn i din kalenderapp for å automatisk synkronisere dine bookinger og planlagte
-                    timer til din digitale kalender
-                </Typography>
-            </Box>
+            <SubHeader
+                title={"Kalender"}
+                startIcon={<CalendarMonthRoundedIcon fontSize={"small"} />}
+                description={
+                    "Kopier denne lenken inn i din kalenderapp for å automatisk synkronisere dine bookinger og planlagte timer til din digitale kalender"
+                }
+            />
             <FormGroup sx={{ gap: "0.75rem" }}>
                 <FormLabel>
                     <TextField

--- a/src/components/modals/Settings/Memberships/Memberships.tsx
+++ b/src/components/modals/Settings/Memberships/Memberships.tsx
@@ -6,6 +6,7 @@ import React, { useState } from "react";
 import AddMembershipDialog from "@/components/modals/Settings/Memberships/AddMembershipDialog";
 import ChainMembership from "@/components/modals/Settings/Memberships/ChainMembership";
 import MembershipLoginModal from "@/components/modals/Settings/Memberships/MembershipLoginModal";
+import SubHeader from "@/components/modals/SubHeader";
 import { ChainIdentifier, ChainProfile } from "@/types/chain";
 import { ChainConfig } from "@/types/config";
 
@@ -29,9 +30,7 @@ function Memberships({
     const hasAllMemberships = Object.keys(chainConfigs).length === chainProfiles.length;
     return (
         <>
-            <Typography variant="h6" sx={{ fontSize: 18 }}>
-                Mine medlemskap
-            </Typography>
+            <SubHeader title={"Mine medlemskap"} sx={{}} />
             {Object.keys(chainConfigs).length === 0 && (
                 <Alert severity={"info"}>
                     <AlertTitle>

--- a/src/components/modals/Settings/Memberships/Memberships.tsx
+++ b/src/components/modals/Settings/Memberships/Memberships.tsx
@@ -30,7 +30,7 @@ function Memberships({
     const hasAllMemberships = Object.keys(chainConfigs).length === chainProfiles.length;
     return (
         <>
-            <SubHeader title={"Mine medlemskap"} sx={{}} />
+            <SubHeader title={"Mine medlemskap"} sx={{ mb: 0 }} />
             {Object.keys(chainConfigs).length === 0 && (
                 <Alert severity={"info"}>
                     <AlertTitle>

--- a/src/components/modals/Settings/PushNotifications.tsx
+++ b/src/components/modals/Settings/PushNotifications.tsx
@@ -3,6 +3,7 @@ import ErrorRoundedIcon from "@mui/icons-material/ErrorRounded";
 import { Box, CircularProgress, FormGroup, FormLabel, Switch, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
+import SubHeader from "@/components/modals/SubHeader";
 import { usePushNotificationSubscription } from "@/lib/hooks/usePushNotificationSubscription";
 import { base64ToUint8Array } from "@/lib/utils/base64Utils";
 
@@ -80,12 +81,7 @@ const PushNotifications = () => {
     return (
         <>
             <FormGroup>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pb: 1 }}>
-                    <Vibration fontSize={"small"} />
-                    <Typography variant="h6" sx={{ fontSize: 18 }}>
-                        Push-varsler
-                    </Typography>
-                </Box>
+                <SubHeader title={"Push-varsler"} startIcon={<Vibration fontSize={"small"} />} />
                 <FormLabel disabled={!isWebPushSupported || subscriptionIsLoading}>
                     <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
                         <Typography

--- a/src/components/modals/Settings/PushNotifications.tsx
+++ b/src/components/modals/Settings/PushNotifications.tsx
@@ -1,8 +1,9 @@
 import { Vibration } from "@mui/icons-material";
 import ErrorRoundedIcon from "@mui/icons-material/ErrorRounded";
-import { Box, CircularProgress, FormGroup, FormLabel, Switch, Typography } from "@mui/material";
+import { Box, FormGroup, FormLabel, Switch, Typography } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
+import SwitchWrapper from "@/components/modals/Settings/SwitchWrapper";
 import SubHeader from "@/components/modals/SubHeader";
 import { usePushNotificationSubscription } from "@/lib/hooks/usePushNotificationSubscription";
 import { base64ToUint8Array } from "@/lib/utils/base64Utils";
@@ -83,36 +84,16 @@ const PushNotifications = () => {
             <FormGroup>
                 <SubHeader title={"Push-varsler"} startIcon={<Vibration fontSize={"small"} />} />
                 <FormLabel disabled={!isWebPushSupported || subscriptionIsLoading}>
-                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
-                        <Typography
-                            sx={{
-                                userSelect: "none",
+                    <SwitchWrapper label={"Bookinger og venneforespørsler"} loading={subscriptionIsLoading}>
+                        <Switch
+                            disabled={!isWebPushSupported}
+                            checked={subscription !== null}
+                            onChange={(_, checked) => (checked ? subscribe() : unsubscribe())}
+                            inputProps={{
+                                "aria-label": "push-varsler-aktiv",
                             }}
-                        >
-                            Bookinger og venneforespørsler
-                        </Typography>
-                        <Box
-                            sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "right",
-                                flexGrow: 1,
-                            }}
-                        >
-                            {subscriptionIsLoading ? (
-                                <CircularProgress size={22} thickness={4} sx={{ margin: "1rem" }} />
-                            ) : (
-                                <Switch
-                                    disabled={!isWebPushSupported}
-                                    checked={subscription !== null}
-                                    onChange={(_, checked) => (checked ? subscribe() : unsubscribe())}
-                                    inputProps={{
-                                        "aria-label": "push-varsler-aktiv",
-                                    }}
-                                />
-                            )}
-                        </Box>
-                    </Box>
+                        />
+                    </SwitchWrapper>
                 </FormLabel>
                 {!isWebPushSupported && !subscriptionIsLoading && (
                     <FormLabel>

--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -4,7 +4,6 @@ import {
     AlertTitle,
     Box,
     Button,
-    CircularProgress,
     Divider,
     FormControl,
     FormGroup,
@@ -24,6 +23,7 @@ import ModalWrapper from "@/components/modals/ModalWrapper";
 import CalendarFeed from "@/components/modals/Settings/CalendarFeed";
 import Memberships from "@/components/modals/Settings/Memberships/Memberships";
 import PushNotifications from "@/components/modals/Settings/PushNotifications";
+import SwitchWrapper from "@/components/modals/Settings/SwitchWrapper";
 import SubHeader from "@/components/modals/SubHeader";
 import { INSTALL_PROMPT_DESCRIPTION } from "@/components/utils/PWAInstallPrompt";
 import SlackSvgIcon from "@/components/utils/SlackSvgIcon";
@@ -212,32 +212,15 @@ export default function Settings({
                                     }
                                 />
                                 <FormLabel>
-                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
-                                        <Typography
-                                            sx={{
-                                                userSelect: "none",
+                                    <SwitchWrapper label={"Påminnelse om time"} loading={notificationsConfigLoading}>
+                                        <Switch
+                                            checked={reminderActive}
+                                            onChange={(_, checked) => handleReminderActiveChanged(checked)}
+                                            inputProps={{
+                                                "aria-label": "påminnelse-aktiv",
                                             }}
-                                        >
-                                            Påminnelse om time
-                                        </Typography>
-                                        <Box
-                                            sx={{
-                                                display: "flex",
-                                                alignItems: "center",
-                                                justifyContent: "right",
-                                                flexGrow: 1,
-                                            }}
-                                        >
-                                            {notificationsConfigLoading && <CircularProgress size="1rem" />}
-                                            <Switch
-                                                checked={reminderActive}
-                                                onChange={(_, checked) => handleReminderActiveChanged(checked)}
-                                                inputProps={{
-                                                    "aria-label": "påminnelse-aktiv",
-                                                }}
-                                            />
-                                        </Box>
-                                    </Box>
+                                        />
+                                    </SwitchWrapper>
                                 </FormLabel>
                                 <Box sx={{ display: "flex", gap: 0.5, alignItems: "center", pb: 1 }}>
                                     <FormControl>

--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -20,6 +20,7 @@ import {
 } from "@mui/material";
 import React, { useEffect, useState } from "react";
 
+import ModalWrapper from "@/components/modals/ModalWrapper";
 import CalendarFeed from "@/components/modals/Settings/CalendarFeed";
 import Memberships from "@/components/modals/Settings/Memberships/Memberships";
 import PushNotifications from "@/components/modals/Settings/PushNotifications";
@@ -178,39 +179,7 @@ export default function Settings({
     );
 
     return (
-        <Box
-            sx={{
-                position: "absolute",
-                top: "50%",
-                left: "50%",
-                width: "90%",
-                maxHeight: "80%",
-                overflowY: "auto",
-                maxWidth: 520,
-                transform: "translate(-50%, -50%)",
-                borderRadius: "0.25em",
-                boxShadow: 24,
-                p: 4,
-                backgroundColor: "white",
-                '[data-mui-color-scheme="dark"] &': {
-                    backgroundColor: "#111",
-                },
-            }}
-        >
-            <Box
-                sx={{
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    gap: 1,
-                    paddingBottom: 2,
-                }}
-            >
-                <SettingsRounded />
-                <Typography variant="h6" component="h2">
-                    Innstillinger
-                </Typography>
-            </Box>
+        <ModalWrapper title={"Innstillinger"} icon={<SettingsRounded />}>
             <Box sx={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
                 {!isPWAInstalled && (
                     <>
@@ -327,6 +296,6 @@ export default function Settings({
                     <CalendarFeed />
                 </FormGroup>
             </Box>
-        </Box>
+        </ModalWrapper>
     );
 }

--- a/src/components/modals/Settings/Settings.tsx
+++ b/src/components/modals/Settings/Settings.tsx
@@ -24,6 +24,7 @@ import ModalWrapper from "@/components/modals/ModalWrapper";
 import CalendarFeed from "@/components/modals/Settings/CalendarFeed";
 import Memberships from "@/components/modals/Settings/Memberships/Memberships";
 import PushNotifications from "@/components/modals/Settings/PushNotifications";
+import SubHeader from "@/components/modals/SubHeader";
 import { INSTALL_PROMPT_DESCRIPTION } from "@/components/utils/PWAInstallPrompt";
 import SlackSvgIcon from "@/components/utils/SlackSvgIcon";
 import { DEFAULT_REMINDER_HOURS, MAX_REMINDER_HOURS, MIN_REMINDER_HOURS } from "@/lib/consts";
@@ -202,14 +203,14 @@ export default function Settings({
                     {features && features.classReminderNotifications && (
                         <>
                             <FormGroup sx={{ py: 2 }}>
-                                <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, pb: 1 }}>
-                                    <SvgIcon fontSize={"small"} sx={{ color: theme.palette.primary.contrastText }}>
-                                        <SlackSvgIcon />
-                                    </SvgIcon>
-                                    <Typography variant="h6" sx={{ fontSize: 18 }}>
-                                        Slack
-                                    </Typography>
-                                </Box>
+                                <SubHeader
+                                    title={"Slack"}
+                                    startIcon={
+                                        <SvgIcon fontSize={"small"} sx={{ color: theme.palette.primary.contrastText }}>
+                                            <SlackSvgIcon />
+                                        </SvgIcon>
+                                    }
+                                />
                                 <FormLabel>
                                     <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
                                         <Typography

--- a/src/components/modals/Settings/SwitchWrapper.tsx
+++ b/src/components/modals/Settings/SwitchWrapper.tsx
@@ -1,0 +1,34 @@
+import { Box, CircularProgress, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+export default function SwitchWrapper({
+    children,
+    label,
+    loading,
+}: {
+    children: ReactNode;
+    label: string;
+    loading?: boolean;
+}) {
+    return (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, pb: 1 }}>
+            <Typography
+                sx={{
+                    userSelect: "none",
+                }}
+            >
+                {label}
+            </Typography>
+            <Box
+                sx={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "right",
+                    flexGrow: 1,
+                }}
+            >
+                {loading ? <CircularProgress size={22} thickness={4} sx={{ margin: "1rem" }} /> : children}
+            </Box>
+        </Box>
+    );
+}

--- a/src/components/modals/SubHeader.tsx
+++ b/src/components/modals/SubHeader.tsx
@@ -1,0 +1,50 @@
+import { Box, SxProps, Typography, useTheme } from "@mui/material";
+import { ReactNode } from "react";
+
+export default function SubHeader({
+    title,
+    startIcon,
+    endIcon,
+    description,
+    placeholder,
+    showPlaceholder,
+    sx = { mb: 1 },
+}: {
+    title: string;
+    startIcon?: ReactNode;
+    endIcon?: ReactNode;
+    description?: string;
+    placeholder?: string;
+    showPlaceholder?: boolean;
+    sx?: SxProps;
+}) {
+    const theme = useTheme();
+    return (
+        <Box sx={sx}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+                {startIcon}
+                <Typography variant="h6" sx={{ fontSize: 18 }}>
+                    {title}
+                </Typography>
+                {endIcon}
+            </Box>
+            {description && (
+                <Typography
+                    variant="body2"
+                    sx={{
+                        color: theme.palette.grey[600],
+                        fontSize: 14,
+                        mt: 0.5,
+                    }}
+                >
+                    {description}
+                </Typography>
+            )}
+            {showPlaceholder && (
+                <Typography variant={"body2"} sx={{ opacity: 0.6, fontStyle: "italic", mt: 0.5 }}>
+                    {placeholder}
+                </Typography>
+            )}
+        </Box>
+    );
+}

--- a/src/components/modals/SubHeader.tsx
+++ b/src/components/modals/SubHeader.tsx
@@ -8,7 +8,7 @@ export default function SubHeader({
     description,
     placeholder,
     showPlaceholder,
-    sx = { mb: 1 },
+    sx,
 }: {
     title: string;
     startIcon?: ReactNode;
@@ -20,7 +20,7 @@ export default function SubHeader({
 }) {
     const theme = useTheme();
     return (
-        <Box sx={sx}>
+        <Box sx={{ mb: 1, ...sx }}>
             <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
                 {startIcon}
                 <Typography variant="h6" sx={{ fontSize: 18 }}>


### PR DESCRIPTION
This PR extracts common markup for the modals to reduce duplication. These bits of code have been copy-pasted over and over, and we really should have extracted them earlier 🤠 

These new components keep the design very similar to before, with slight changes due to the standardization of components where our original code differs slightly. 