### PR TITLE
feat: add enable flag for exclude class time filters

### DIFF
--- a/src/components/Chain.tsx
+++ b/src/components/Chain.tsx
@@ -34,7 +34,7 @@ import {
     BookingPopupAction,
     BookingPopupState,
     ChainProfile,
-    ExcludeClassTimeFilter,
+    ExcludeClassTimeFiltersType,
     RezervoChain,
     RezervoClass,
     RezervoWeekSchedule,
@@ -85,7 +85,10 @@ function Chain({
 
     const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>(initialLocationIds);
     const [selectedCategories, setSelectedCategories] = useState<string[]>(activityCategories.map((ac) => ac.name));
-    const [excludeClassTimeFilters, setExcludeClassTimeFilters] = useState<ExcludeClassTimeFilter[]>([]);
+    const [excludeClassTimeFilters, setExcludeClassTimeFilters] = useState<ExcludeClassTimeFiltersType>({
+        enabled: true,
+        filters: [],
+    });
     const [selectedChain, setSelectedChain] = useState<string | null>(null);
 
     const [weekParam] = useQueryState(
@@ -102,7 +105,7 @@ function Chain({
         setSelectedCategories(
             getStoredSelectedCategories(chain.profile.identifier) ?? activityCategories.map((ac) => ac.name),
         );
-        setExcludeClassTimeFilters(getStoredExcludeClassTimeFilters() ?? []);
+        setExcludeClassTimeFilters(getStoredExcludeClassTimeFilters() ?? { enabled: true, filters: [] });
         setSelectedChain(chain.profile.identifier);
     }, [chain.profile.identifier, defaultLocationIds, activityCategories]);
 

--- a/src/components/modals/ScheduleFiltersDialog.tsx
+++ b/src/components/modals/ScheduleFiltersDialog.tsx
@@ -10,7 +10,7 @@ import SwipeableViews from "react-swipeable-views";
 import CategoryFilters from "@/components/modals/CategoryFilters";
 import ExcludeClassTimeFilters from "@/components/modals/ExcludeClassTimeFilters";
 import LocationFilters from "@/components/modals/LocationFilters";
-import { ActivityCategory, ExcludeClassTimeFilter, RezervoChain } from "@/types/chain";
+import { ActivityCategory, ExcludeClassTimeFiltersType, RezervoChain } from "@/types/chain";
 
 function a11yProps(index: number) {
     return {
@@ -74,8 +74,8 @@ export default function ScheduleFiltersDialog({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
-    excludeClassTimeFilters: ExcludeClassTimeFilter[];
-    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+    excludeClassTimeFilters: ExcludeClassTimeFiltersType;
+    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFiltersType>>;
 }) {
     const theme = useTheme();
     const [tab, setTab] = useState(0);

--- a/src/components/schedule/DaySchedule.tsx
+++ b/src/components/schedule/DaySchedule.tsx
@@ -6,14 +6,14 @@ import CurrentTimeDivider from "@/components/schedule/CurrentTimeDivider";
 import {
     getCapitalizedWeekday,
     isClassInThePast,
-    isClassExcludedByTimeFilter,
     isDayPassed,
     isToday,
     LocalizedDateTime,
+    isClassExcludedByTimeFilters,
 } from "@/lib/helpers/date";
 import { classRecurrentId } from "@/lib/helpers/recurrentId";
 import { hexWithOpacityToRgb } from "@/lib/utils/colorUtils";
-import { ChainIdentifier, ExcludeClassTimeFilter, RezervoClass, RezervoDaySchedule } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFiltersType, RezervoClass, RezervoDaySchedule } from "@/types/chain";
 import { ClassPopularity, ClassPopularityIndex } from "@/types/popularity";
 
 function DaySchedule({
@@ -33,7 +33,7 @@ function DaySchedule({
     daySchedule: RezervoDaySchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
-    excludeClassTimeFilters: ExcludeClassTimeFilter[];
+    excludeClassTimeFilters: ExcludeClassTimeFiltersType;
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;
@@ -49,7 +49,7 @@ function DaySchedule({
                 (c) =>
                     selectedLocationIds.includes(c.location.id) &&
                     selectedCategories.includes(c.activity.category) &&
-                    !excludeClassTimeFilters.some((filter) => isClassExcludedByTimeFilter(c, filter)),
+                    !isClassExcludedByTimeFilters(c, excludeClassTimeFilters),
             ),
         [daySchedule.classes, selectedLocationIds, selectedCategories, excludeClassTimeFilters],
     );

--- a/src/components/schedule/WeekNavigator.tsx
+++ b/src/components/schedule/WeekNavigator.tsx
@@ -12,7 +12,7 @@ import ScheduleFiltersDialog, {
 } from "@/components/modals/ScheduleFiltersDialog";
 import { ISO_WEEK_QUERY_PARAM, SCROLL_TO_NOW_QUERY_PARAM } from "@/lib/consts";
 import { compactISOWeekString, fromCompactISOWeekString, LocalizedDateTime } from "@/lib/helpers/date";
-import { ActivityCategory, ExcludeClassTimeFilter, RezervoChain } from "@/types/chain";
+import { ActivityCategory, ExcludeClassTimeFiltersType, RezervoChain } from "@/types/chain";
 
 export default function WeekNavigator({
     chain,
@@ -36,8 +36,8 @@ export default function WeekNavigator({
     allCategories: ActivityCategory[];
     selectedCategories: string[];
     setSelectedCategories: Dispatch<SetStateAction<string[]>>;
-    excludeClassTimeFilters: ExcludeClassTimeFilter[];
-    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFilter[]>>;
+    excludeClassTimeFilters: ExcludeClassTimeFiltersType;
+    setExcludeClassTimeFilters: Dispatch<SetStateAction<ExcludeClassTimeFiltersType>>;
 }) {
     const [weekParam, setWeekParam] = useQueryState(ISO_WEEK_QUERY_PARAM);
     const [scrollToNowParam, setScrollToNowParam] = useQueryState(SCROLL_TO_NOW_QUERY_PARAM, parseAsBoolean);
@@ -52,7 +52,7 @@ export default function WeekNavigator({
     }, [selectedCategories, allCategories]);
 
     const isClassTimeFiltered = useMemo(() => {
-        return excludeClassTimeFilters.length > 0;
+        return excludeClassTimeFilters.enabled && excludeClassTimeFilters.filters.some((filter) => filter.enabled);
     }, [excludeClassTimeFilters]);
 
     const isFiltered = isLocationFiltered || isCategoryFiltered || isClassTimeFiltered;
@@ -149,7 +149,7 @@ export default function WeekNavigator({
                                     backgroundColor: EXCLUDE_CLASS_TIME_COLOR[500],
                                 }}
                             >
-                                {excludeClassTimeFilters.length}
+                                {excludeClassTimeFilters.filters.filter((filter) => filter.enabled).length}
                             </Avatar>
                         )}
                     </Box>

--- a/src/components/schedule/WeekSchedule.tsx
+++ b/src/components/schedule/WeekSchedule.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import DaySchedule from "@/components/schedule/DaySchedule";
 import { isToday } from "@/lib/helpers/date";
-import { ChainIdentifier, ExcludeClassTimeFilter, RezervoClass, RezervoWeekSchedule } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFiltersType, RezervoClass, RezervoWeekSchedule } from "@/types/chain";
 import { ClassPopularityIndex } from "@/types/popularity";
 
 function WeekSchedule({
@@ -23,7 +23,7 @@ function WeekSchedule({
     weekSchedule: RezervoWeekSchedule;
     selectedLocationIds: string[];
     selectedCategories: string[];
-    excludeClassTimeFilters: ExcludeClassTimeFilter[];
+    excludeClassTimeFilters: ExcludeClassTimeFiltersType;
     classPopularityIndex: ClassPopularityIndex;
     selectable: boolean;
     selectedClassIds: string[] | null;

--- a/src/lib/helpers/date.ts
+++ b/src/lib/helpers/date.ts
@@ -1,7 +1,7 @@
 import { DateTime, Info, Settings } from "luxon";
 import { IfValid } from "luxon/src/_util";
 
-import { ExcludeClassTimeFilter, RezervoClass } from "@/types/chain";
+import { ExcludeClassTimeFilter, ExcludeClassTimeFiltersType, RezervoClass } from "@/types/chain";
 
 export const compactISOWeekString = <IsValid extends boolean>(
     date: DateTime<IsValid>,
@@ -62,10 +62,26 @@ export const LocalizedDateTime: typeof DateTime = (() => {
     return DateTime;
 })();
 
+export const isClassExcludedByTimeFilters = (
+    _class: RezervoClass,
+    excludeClassTimeFilters: ExcludeClassTimeFiltersType,
+): boolean => {
+    if (!excludeClassTimeFilters.enabled) {
+        return false;
+    }
+    return excludeClassTimeFilters.filters.some((filter) => {
+        return isClassExcludedByTimeFilter(_class, filter);
+    });
+};
+
 export const isClassExcludedByTimeFilter = (
     _class: RezervoClass,
     excludeClassTimeFilter: ExcludeClassTimeFilter,
 ): boolean => {
+    if (!excludeClassTimeFilter.enabled) {
+        return false;
+    }
+
     if (
         _class.startTime.weekday !== excludeClassTimeFilter.weekday &&
         _class.endTime.weekday !== excludeClassTimeFilter.weekday

--- a/src/lib/helpers/storage.ts
+++ b/src/lib/helpers/storage.ts
@@ -1,6 +1,6 @@
 import Cookies from "js-cookie";
 
-import { ChainIdentifier, ExcludeClassTimeFilter } from "@/types/chain";
+import { ChainIdentifier, ExcludeClassTimeFilter, ExcludeClassTimeFiltersType } from "@/types/chain";
 
 const STORAGE_KEY_PREFIX = "rezervo.";
 const STORAGE_KEYS = {
@@ -49,12 +49,27 @@ export function getStoredSelectedCategories(chainIdentifier: string): string[] |
     return getStoredValue<string[]>(STORAGE_KEYS.selectedCategories(chainIdentifier), true);
 }
 
-export function storeExcludeClassTimeFilters(excludeClassTimeFilters: ExcludeClassTimeFilter[]) {
+export function storeExcludeClassTimeFilters(excludeClassTimeFilters: ExcludeClassTimeFiltersType) {
     storeValue(STORAGE_KEYS.excludeClassTimeFilters, excludeClassTimeFilters);
 }
 
-export function getStoredExcludeClassTimeFilters(): ExcludeClassTimeFilter[] | null {
-    return getStoredValue<ExcludeClassTimeFilter[]>(STORAGE_KEYS.excludeClassTimeFilters, true);
+export function getStoredExcludeClassTimeFilters(): ExcludeClassTimeFiltersType | null {
+    const storedExcludeClassTimeFilters = getStoredValue<ExcludeClassTimeFiltersType | ExcludeClassTimeFilter[]>(
+        STORAGE_KEYS.excludeClassTimeFilters,
+        true,
+    );
+    // todo: this is to migrate old client-side data, remove else-case once users have been given time to migrate
+    if (!Array.isArray(storedExcludeClassTimeFilters)) {
+        return storedExcludeClassTimeFilters;
+    } else {
+        storedExcludeClassTimeFilters.map((excludeClassTimeFilter) => {
+            if (excludeClassTimeFilter.enabled === undefined) {
+                excludeClassTimeFilter.enabled = true;
+            }
+            return excludeClassTimeFilter;
+        });
+        return { enabled: true, filters: storedExcludeClassTimeFilters };
+    }
 }
 
 export function storePreLoginPath(path: string) {

--- a/src/lib/helpers/storage.ts
+++ b/src/lib/helpers/storage.ts
@@ -62,13 +62,15 @@ export function getStoredExcludeClassTimeFilters(): ExcludeClassTimeFiltersType 
     if (!Array.isArray(storedExcludeClassTimeFilters)) {
         return storedExcludeClassTimeFilters;
     } else {
-        storedExcludeClassTimeFilters.map((excludeClassTimeFilter) => {
-            if (excludeClassTimeFilter.enabled === undefined) {
-                excludeClassTimeFilter.enabled = true;
-            }
-            return excludeClassTimeFilter;
-        });
-        return { enabled: true, filters: storedExcludeClassTimeFilters };
+        const filters = {
+            enabled: true,
+            filters: storedExcludeClassTimeFilters.map((f) => ({
+                ...f,
+                enabled: f.enabled ?? true,
+            })),
+        };
+        storeExcludeClassTimeFilters(filters);
+        return filters;
     }
 }
 

--- a/src/types/chain.ts
+++ b/src/types/chain.ts
@@ -112,4 +112,10 @@ export type ExcludeClassTimeFilter = {
     startMinute: MinuteNumbers;
     endHour: HourNumbers;
     endMinute: MinuteNumbers;
+    enabled: boolean;
+};
+
+export type ExcludeClassTimeFiltersType = {
+    enabled: boolean;
+    filters: ExcludeClassTimeFilter[];
 };


### PR DESCRIPTION
Current "Exclude class time"-filter page:
![image](https://github.com/user-attachments/assets/13687399-8a7e-43e2-9782-e1cb1ce9d5ae)

New "Exclude class time"-filter page:
![image](https://github.com/user-attachments/assets/2f8a9dc6-6c0a-4ebb-bca1-b93d39c35da0)

Details are hidden when the entire filter is disabled:
![image](https://github.com/user-attachments/assets/9843edfa-2feb-48c4-8ab6-5fafb4ae4448)
